### PR TITLE
Fix random population generation and save injections

### DIFF
--- a/example_config.ini
+++ b/example_config.ini
@@ -5,10 +5,9 @@ error_size = 2000
 root_container = syn_data
 event_filename = event_{}.dat
 config_filename = configuration.csv
-num_realizations = 2
+num_realizations = 10
 
 [selection_effect]
-; vt_filename = vt_m1_m2.hdf5
 vt_filename = new_vt2.h5
 vt_columns = ['m1_source','m2_source']
 


### PR DESCRIPTION
This pull request fixes #38 by updating the `generate_injections` method in the `popgen.py` file. The method now correctly generates the random population from the selected mass, spin, and eccentricity model, and saves those injections into an `injections.dat` file. Additionally, the method now generates plots for the injections, including mass and eccentricity plots.