### PR TITLE
Apply VT effects on injections and store weighted events

### DIFF
--- a/example_config.ini
+++ b/example_config.ini
@@ -8,8 +8,8 @@ config_filename = configuration.csv
 num_realizations = 10
 
 [selection_effect]
-vt_filename = new_vt2.h5
-vt_columns = ['m1_source','m2_source']
+; vt_filename = new_vt2.h5
+vt_filename = mass_vt.hdf5
 
 [mass_model]
 model = Wysocki2019MassModel

--- a/gwkokab/_src/utils/parser.py
+++ b/gwkokab/_src/utils/parser.py
@@ -47,7 +47,4 @@ def parse_config(config_path: str) -> dict:
     config_dict["general"]["error_size"] = int(config["general"]["error_size"])
     config_dict["general"]["num_realizations"] = int(config["general"]["num_realizations"])
 
-    if "selection_effect" in config:
-        config_dict["selection_effect"]["vt_columns"] = eval(config["selection_effect"]["vt_columns"])
-
     return config_dict

--- a/gwkokab/_src/vts/utils.py
+++ b/gwkokab/_src/vts/utils.py
@@ -41,7 +41,8 @@ def interpolate_hdf5(hdf5_file):
     """
     m1_grid = jnp.exp(jnp.asarray(hdf5_file["logM"]))
     m2_grid = jnp.exp(jnp.asarray(hdf5_file["logM"]))
-    VT_grid = jnp.asarray(hdf5_file["VT"][0, 0, :, :])
+    # VT_grid = jnp.asarray(hdf5_file["VT"][0, 0, :, :])
+    VT_grid = jnp.asarray(hdf5_file["VT"][:])
 
     return interpolate(m1_grid, m2_grid, VT_grid)
 


### PR DESCRIPTION
This pull request fixes #39 by applying the VT effects on injections and storing the weighted events in the `weighted.dat` file. The changes include modifying the `parse_config` function in `parser.py`, and updating the `weight_over_m1m2` function in `popgen.py`. Additionally, the `weighted_injection` function is added to handle the weighting of injections using the VT file. The `interpolate_hdf5` function in `utils.py` is also modified to correctly read the VT data.