### PR TITLE
Depreciates partial constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,19 +4,20 @@ Best view [here](https://gwkokab.readthedocs.io/en/latest/changelog.html).
 
 ## gwkokab 0.0.2
 
-### Breaking changes
+**Breaking changes**
 
 * `gwkokab.priors.UnnormalizedUniform` deprecated in favor of `numpyro.distributions.ImproperUniform`.
 * Trivial errors are removed from `gwkokab.errors` module.
   * `normal_error`
   * `truncated_normal_error`
   * `uniform_error`
+* After the release of [numpyro-0.15.1](https://github.com/pyro-ppl/numpyro/releases/tag/0.15.1), `less_than_equals_to` and `greater_than_equals_to` constraints are removed from `gwkokab.constraints` module.
 
-### New features
+**New features**
 
 * Constraints related to closed intervals, for details, see [PR#125](https://github.com/gwkokab/gwkokab/pull/125).
 * Bijective transformations on different mass coordinates, for details, see [PR#125](https://github.com/gwkokab/gwkokab/pull/125).
 
-## gwkokab 0.0.1
+## gwkokab 0.0.1 (Jul 5, 2024)
 
 * Initial release.

--- a/gwkokab/_src/models/utils/constraints.py
+++ b/gwkokab/_src/models/utils/constraints.py
@@ -24,9 +24,7 @@ from numpyro.distributions.constraints import (
 
 __all__ = [
     "decreasing_vector",
-    "greater_than_equal_to",
     "increasing_vector",
-    "less_than_equal_to",
     "mass_ratio_mass_sandwich",
     "mass_sandwich",
     "positive_decreasing_vector",
@@ -35,38 +33,6 @@ __all__ = [
     "strictly_increasing_vector",
     "unique_intervals",
 ]
-
-
-class _GreaterThanEqualTo(Constraint):
-    r"""Constrain values to be greater than or equal to a given value."""
-
-    def __init__(self, lower_bound: float):
-        r"""
-        :param lower_bound: The lower bound.
-        """
-        self.lower_bound = lower_bound
-
-    def __call__(self, x):
-        return x >= self.lower_bound
-
-    def tree_flatten(self):
-        return (self.lower_bound,), (("lower_bound",), dict())
-
-
-class _LessThanEqualTo(Constraint):
-    r"""Constrain values to be less than or equal to a given value."""
-
-    def __init__(self, upper_bound: float):
-        """
-        :param upper_bound: The upper bound.
-        """
-        self.upper_bound = upper_bound
-
-    def __call__(self, x):
-        return x <= self.upper_bound
-
-    def tree_flatten(self):
-        return (self.upper_bound,), (("upper_bound",), dict())
 
 
 class _MassSandwichConstraint(Constraint):
@@ -272,8 +238,6 @@ class _PositiveDecreasingVector(_SingletonConstraint):
         return isinstance(other, _PositiveDecreasingVector)
 
 
-greater_than_equal_to = _GreaterThanEqualTo
-less_than_equal_to = _LessThanEqualTo
 mass_sandwich = _MassSandwichConstraint
 mass_ratio_mass_sandwich = _MassRationMassSandwichConstraint
 unique_intervals = _UniqueIntervals

--- a/gwkokab/models/constraints.py
+++ b/gwkokab/models/constraints.py
@@ -15,9 +15,7 @@
 
 from gwkokab._src.models.utils.constraints import (
     decreasing_vector as decreasing_vector,
-    greater_than_equal_to as greater_than_equal_to,
     increasing_vector as increasing_vector,
-    less_than_equal_to as less_than_equal_to,
     mass_ratio_mass_sandwich as mass_ratio_mass_sandwich,
     mass_sandwich as mass_sandwich,
     positive_decreasing_vector as positive_decreasing_vector,


### PR DESCRIPTION
closes #106

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added constraints for closed intervals and bijective transformations.

- **Deprecations**
  - Deprecated `UnnormalizedUniform` in favor of `ImproperUniform` from `numpyro`.

- **Removals**
  - Removed trivial errors from the error handling module.
  - Removed `less_than_equals_to` and `greater_than_equals_to` constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->