### PR TITLE
dept: no more truncated power law model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Best view [here](https://gwkokab.readthedocs.io/en/latest/changelog.html).
 
 ## gwkokab 0.1.1
 
+**Breaking changes**
+
+* `TruncatedPowerLaw` is removed from the public API.
+
 **New Design**
 
 * Introduced a refined base class for smoothed mass distribution models, enhancing functionality and maintainability.

--- a/gwkokab/_src/models/__init__.py
+++ b/gwkokab/_src/models/__init__.py
@@ -23,6 +23,5 @@ from .models import (
     NPowerLawMGaussianWithDefaultSpinMagnitudeAndSpinMisalignment as NPowerLawMGaussianWithDefaultSpinMagnitudeAndSpinMisalignment,
     PowerLawPeakMassModel as PowerLawPeakMassModel,
     PowerLawPrimaryMassRatio as PowerLawPrimaryMassRatio,
-    TruncatedPowerLaw as TruncatedPowerLaw,
     Wysocki2019MassModel as Wysocki2019MassModel,
 )

--- a/gwkokab/models/__init__.py
+++ b/gwkokab/models/__init__.py
@@ -24,7 +24,6 @@ from gwkokab._src.models.models import (
     NPowerLawMGaussianWithDefaultSpinMagnitudeAndSpinMisalignment as NPowerLawMGaussianWithDefaultSpinMagnitudeAndSpinMisalignment,
     PowerLawPeakMassModel as PowerLawPeakMassModel,
     PowerLawPrimaryMassRatio as PowerLawPrimaryMassRatio,
-    TruncatedPowerLaw as TruncatedPowerLaw,
     Wysocki2019MassModel as Wysocki2019MassModel,
 )
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
	- Removed the `TruncatedPowerLaw` model from the public API, which may require users to update existing implementations.

- **New Features**
	- Introduced a new function for computing the inverse cumulative distribution function (ICDF) for a doubly truncated power law distribution.
	- Enhanced log probability functions for improved accuracy and efficiency.

- **Bug Fixes**
	- Updated the internal logic of statistical functions to provide more accurate calculations for log probabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->