### PR TITLE
gh-78(dept): Truncated Power Law removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Best view [here](https://gwkokab.readthedocs.io/en/latest/changelog.html).
 * Following models have been depreciated,
   * `MultiSourceModel`
   * `MultiSpinModel`
+  * `TruncatedPowerLaw`
 
 **New features**
 

--- a/docs/source/gwkokab.models.rst
+++ b/docs/source/gwkokab.models.rst
@@ -23,7 +23,6 @@ Models
     NPowerLawMGaussianWithSpinMisalignment
     PowerLawPeakMassModel
     PowerLawPrimaryMassRatio
-    TruncatedPowerLaw
     Wysocki2019MassModel
 
 Utilities

--- a/src/gwkokab/_src/models/__init__.py
+++ b/src/gwkokab/_src/models/__init__.py
@@ -26,6 +26,5 @@ from .models import (
     NPowerLawMGaussianWithSpinMisalignment as NPowerLawMGaussianWithSpinMisalignment,
     PowerLawPeakMassModel as PowerLawPeakMassModel,
     PowerLawPrimaryMassRatio as PowerLawPrimaryMassRatio,
-    TruncatedPowerLaw as TruncatedPowerLaw,
     Wysocki2019MassModel as Wysocki2019MassModel,
 )

--- a/src/gwkokab/_src/models/utils.py
+++ b/src/gwkokab/_src/models/utils.py
@@ -28,8 +28,6 @@ from ..utils.math import beta_dist_mean_variance_to_concentrations
 
 
 __all__ = [
-    "doubly_truncated_powerlaw_icdf",
-    "doubly_truncated_powerlaw_log_prob",
     "get_default_spin_magnitude_dists",
     "get_spin_misalignment_dist",
     "JointDistribution",
@@ -173,50 +171,3 @@ def get_spin_misalignment_dist(
         validate_args=True,
     )
     return cos_tilt1_dist, cos_tilt2_dist
-
-
-def doubly_truncated_powerlaw_log_prob(value, alpha, low, high):
-    def logp_neg1(value):
-        logp_neg1_val = jnp.divide(high, low)
-        logp_neg1_val = jnp.log(logp_neg1_val)
-        logp_neg1_val = jnp.multiply(value, logp_neg1_val)
-        logp_neg1_val = jnp.log(logp_neg1_val)
-        return jnp.negative(logp_neg1_val)
-
-    def logp(value):
-        log_value = jnp.log(value)
-        logp = jnp.multiply(alpha, log_value)
-        beta = jnp.add(1.0, alpha)
-        logp = jnp.add(
-            logp,
-            jnp.log(
-                jnp.divide(
-                    beta,
-                    jnp.subtract(jnp.power(high, beta), jnp.power(low, beta)),
-                )
-            ),
-        )
-        return logp
-
-    return jnp.where(jnp.equal(alpha, -1.0), logp_neg1(value), logp(value))
-
-
-def doubly_truncated_powerlaw_icdf(q, alpha, low, high):
-    def icdf(q):
-        beta = jnp.add(1.0, alpha)
-        low_pow_beta = jnp.power(low, beta)
-        high_pow_beta = jnp.power(high, beta)
-        icdf = jnp.multiply(q, jnp.subtract(high_pow_beta, low_pow_beta))
-        icdf = jnp.add(low_pow_beta, icdf)
-        icdf = jnp.power(icdf, jnp.reciprocal(beta))
-        return icdf
-
-    def icdf_neg1(q):
-        icdf_neg1 = jnp.divide(high, low)
-        icdf_neg1 = jnp.log(icdf_neg1)
-        icdf_neg1 = jnp.multiply(q, icdf_neg1)
-        icdf_neg1 = jnp.exp(icdf_neg1)
-        icdf_neg1 = jnp.multiply(low, icdf_neg1)
-        return icdf_neg1
-
-    return jnp.where(jnp.equal(alpha, -1.0), icdf_neg1(q), icdf(q))

--- a/src/gwkokab/models/__init__.py
+++ b/src/gwkokab/models/__init__.py
@@ -27,7 +27,6 @@ from gwkokab._src.models.models import (
     NPowerLawMGaussianWithSpinMisalignment as NPowerLawMGaussianWithSpinMisalignment,
     PowerLawPeakMassModel as PowerLawPeakMassModel,
     PowerLawPrimaryMassRatio as PowerLawPrimaryMassRatio,
-    TruncatedPowerLaw as TruncatedPowerLaw,
     Wysocki2019MassModel as Wysocki2019MassModel,
 )
 


### PR DESCRIPTION
https://github.com/pyro-ppl/numpyro/issues/1806 has been solved by https://github.com/pyro-ppl/numpyro/pull/1807, and merged and released in [NumPyro-0.15.3](https://github.com/pyro-ppl/numpyro/releases/tag/0.15.3), we no longer need `TruncatedPowerLaw`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the `DoublyTruncatedPowerLaw` class for enhanced modeling of power law distributions.
  
- **Deprecations**
	- Deprecated the `TruncatedPowerLaw`, `MultiSourceModel`, and `MultiSpinModel`, indicating they are no longer recommended for use.

- **Documentation**
	- Updated documentation to reflect the removal of the `TruncatedPowerLaw` model from the public API.

- **Bug Fixes**
	- Streamlined various methods to utilize the new `DoublyTruncatedPowerLaw` class, improving performance and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->