### PR TITLE
feat: API for non-uniform priors in JSON file

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,7 +16,8 @@ help:
 
 install: uninstall
 ifndef UV_CHECK
-	$(error "$(UV) is not installed. Please install it first")
+	@echo "uv is not installed. Continuing without uv."
+	$(PIP) install $(PIP_FLAGS) .
 endif
 	$(UV) $(PIP) install $(PIP_FLAGS) .
 
@@ -25,4 +26,6 @@ uninstall:
 
 cache_clean: uninstall
 	$(PIP) cache purge
+ifdef UV_CHECK
 	$(UV) cache clean
+endif

--- a/src/kokab/utils/priors.py
+++ b/src/kokab/utils/priors.py
@@ -1,0 +1,32 @@
+# Copyright 2023 The GWKokab Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Copyright (c) 2024 Colm Talbot
+# SPDX-License-Identifier: MIT
+
+import numpyro.distributions
+from numpyro.distributions import Distribution
+
+
+class _Available:
+    def __getitem__(self, name: str) -> Distribution:
+        if not (ord("A") <= ord(name[0]) <= ord("Z")):
+            raise AttributeError(f"module {__name__} is an invalid prior")
+        if name in numpyro.distributions.__all__:
+            return getattr(numpyro.distributions, name)
+        raise AttributeError(f"module {__name__} has no attribute {name}")
+
+
+available = _Available()


### PR DESCRIPTION
Formally we were providing priors as a list of two elements where the value at index 0 is low and the value at index 1 is high. It has restricted us to uniform priors. Now we can provide priors in the following format allowing a broader category of priors to be passed.

```json
{
  "log_rate_0": { "dist": "Uniform", "low": -3.0, "high": 10.0 },
  "log_rate_1": "log_rate_0",
  "alpha_pl_0": { "dist": "Uniform", "low": -4.0, "high": 12.0 },
  "beta_pl_0": { "dist": "Uniform", "low": -2.0, "high": 7.0 },
  "mmin_pl_0": { "dist": "Uniform", "low": 2.0, "high": 10.0 },
  "mmax_pl_0": { "dist": "Uniform", "low": 30.0, "high": 100.0 },
  "delta_pl_0": { "dist": "Uniform", "low": 0, "high": 10 },
  "loc_g_0": { "dist": "Uniform", "low": 20, "high": 50 },
  "scale_g_0": { "dist": "Uniform", "low": 1, "high": 10 },
  "beta_g_0": "beta_pl_0",
  "mmin_g_0": "mmin_pl_0",
  "delta_g_0": "delta_pl_0",
}

```