### PR TITLE
chore(ci): remove documentation rendering step from CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,3 @@ jobs:
           PY_COLORS: 1
         run: |
           uv run pytest docs --tb=short --doctest-glob='*.md' --doctest-glob='*.rst' --doctest-continue-on-failure
-      - name: Render documentation
-        run: |
-          source .venv/bin/activate
-          cd docs
-          make html


### PR DESCRIPTION
We have added readthedoc webhook to eye on the build status of documentation after which we do not require the removed step.