### PR TITLE
fix: handle NaN and infinite values in log posterior calculation

### DIFF
--- a/src/gwkokab/inference/poissonlikelihood.py
+++ b/src/gwkokab/inference/poissonlikelihood.py
@@ -190,4 +190,11 @@ class PoissonLikelihood(eqx.Module):
             lp=log_prior,
             ll=log_likelihood,
         )
-        return log_prior + log_likelihood
+        log_posterior = log_prior + log_likelihood
+        log_posterior = jnp.nan_to_num(
+            log_posterior,
+            nan=-jnp.inf,
+            posinf=-jnp.inf,
+            neginf=-jnp.inf,
+        )
+        return log_posterior


### PR DESCRIPTION
After troublesome attempts to handle `jnp.nans` manually, we have surrendered to converting them to `-jnp.inf`.