### PR TITLE
feat: use fix grid of primary mass and mass ratio to compute normalization constants

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "chex>=0.1.87",
     "flowMC>=0.3.4",
     "h5py>=3.12.1",
+    "interpax>=0.3.5",
     "jax>=0.4.30",
     "jaxlib>=0.4.30",
     "jaxtyping>=0.2.36",


### PR DESCRIPTION
Using a fixed grid with less dimension to compute normalization constants of the smoothing mass model offers a great trade-off in optimization while compromising less on accuracy.