### PR TITLE
refactor(gh-451): replace `jax.vmap` with `jax.lax.map` for logVT function in neural and population models

### DIFF
--- a/src/gwkokab/vts/_abc.py
+++ b/src/gwkokab/vts/_abc.py
@@ -38,8 +38,8 @@ class VolumeTimeSensitivityInterface(eqx.Module):
         raise NotImplementedError
 
     @abstractmethod
-    def get_vmapped_logVT(self) -> Callable[[Array], Array]:
-        """Gets a vectorized log volume-time sensitivity function for batch processing.
+    def get_mapped_logVT(self) -> Callable[[Array], Array]:
+        """Gets a mapped log volume-time sensitivity function for batch processing.
 
         Returns
         -------

--- a/src/gwkokab/vts/_neuralvt.py
+++ b/src/gwkokab/vts/_neuralvt.py
@@ -12,11 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+
 from collections.abc import Callable, Sequence
 
 import equinox as eqx
 import jax
-from jax import numpy as jnp
+from jax import lax, numpy as jnp
 from jaxtyping import Array
 
 from ._abc import VolumeTimeSensitivityInterface
@@ -65,11 +66,9 @@ class NeuralNetVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
     def get_vmapped_logVT(self) -> Callable[[Array], Array]:
         """Gets the vmapped logVT function for batch processing."""
 
-        neural_vt_model_vmap = jax.vmap(self.neural_vt_model)
-
         @jax.jit
         def _logVT(x: Array) -> Array:
             x_new = x[..., self.shuffle_indices]
-            return jnp.squeeze(neural_vt_model_vmap(x_new), axis=-1)
+            return jnp.squeeze(lax.map(self.neural_vt_model, x_new), axis=-1)
 
         return _logVT

--- a/src/gwkokab/vts/_neuralvt.py
+++ b/src/gwkokab/vts/_neuralvt.py
@@ -63,7 +63,7 @@ class NeuralNetVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
 
         return _logVT
 
-    def get_vmapped_logVT(self) -> Callable[[Array], Array]:
+    def get_mapped_logVT(self) -> Callable[[Array], Array]:
         """Gets the vmapped logVT function for batch processing."""
 
         @jax.jit

--- a/src/gwkokab/vts/_popmodelvt.py
+++ b/src/gwkokab/vts/_popmodelvt.py
@@ -266,7 +266,7 @@ class PopModelsVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
 
         return _logVT
 
-    def get_vmapped_logVT(self) -> Callable[[Array], Array]:
+    def get_mapped_logVT(self) -> Callable[[Array], Array]:
         return lambda x: jax.lax.map(self.get_logVT(), x)
 
 

--- a/src/gwkokab/vts/_popmodelvt.py
+++ b/src/gwkokab/vts/_popmodelvt.py
@@ -267,7 +267,7 @@ class PopModelsVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
         return _logVT
 
     def get_vmapped_logVT(self) -> Callable[[Array], Array]:
-        return jax.vmap(self.get_logVT(), in_axes=0, out_axes=0)
+        return lambda x: jax.lax.map(self.get_logVT(), x)
 
 
 # source: https://gitlab.com/dwysocki/bayesian-parametric-population-models/-/blob/master/src/pop_models/astro_models/gw_ifo_vt.py?ref_type=heads#L554-709

--- a/src/kokab/chi_eff_q_relation/sage.py
+++ b/src/kokab/chi_eff_q_relation/sage.py
@@ -117,7 +117,7 @@ def main() -> None:
     nvt = vt_json_read_and_process(
         [param.name for param in parameters], args.vt_path, args.vt_json
     )
-    logVT = nvt.get_vmapped_logVT()
+    logVT = nvt.get_mapped_logVT()
 
     pmean_kwargs = poisson_mean_parser.poisson_mean_parser(args.pmean_json)
     erate_estimator = PoissonMean(logVT, KEY4, **pmean_kwargs)

--- a/src/kokab/ecc_matters/genie.py
+++ b/src/kokab/ecc_matters/genie.py
@@ -124,7 +124,7 @@ def main() -> None:
     model_parameters = [m1_source, m2_source, ecc]
 
     nvt = vt_json_read_and_process(model_parameters, args.vt_path, args.vt_json)
-    logVT = nvt.get_vmapped_logVT()
+    logVT = nvt.get_mapped_logVT()
 
     pmean_kwargs = poisson_mean_parser.poisson_mean_parser(args.pmean_json)
     erate_estimator = PoissonMean(

--- a/src/kokab/ecc_matters/sage.py
+++ b/src/kokab/ecc_matters/sage.py
@@ -77,7 +77,7 @@ def main() -> None:
     nvt = vt_json_read_and_process(
         [param.name for param in parameters], args.vt_path, args.vt_json
     )
-    logVT = nvt.get_vmapped_logVT()
+    logVT = nvt.get_mapped_logVT()
 
     pmean_kwargs = poisson_mean_parser.poisson_mean_parser(args.pmean_json)
     erate_estimator = PoissonMean(logVT, KEY4, **pmean_kwargs)

--- a/src/kokab/n_pls_m_gs/genie.py
+++ b/src/kokab/n_pls_m_gs/genie.py
@@ -360,7 +360,7 @@ def main() -> None:
     )
 
     nvt = vt_json_read_and_process(parameters_name, args.vt_path, args.vt_json)
-    logVT = nvt.get_vmapped_logVT()
+    logVT = nvt.get_mapped_logVT()
 
     pmean_kwargs = poisson_mean_parser.poisson_mean_parser(args.pmean_json)
     erate_estimator = PoissonMean(

--- a/src/kokab/n_pls_m_gs/sage.py
+++ b/src/kokab/n_pls_m_gs/sage.py
@@ -239,7 +239,7 @@ def main() -> None:
     nvt = vt_json_read_and_process(
         [param.name for param in parameters], args.vt_path, args.vt_json
     )
-    logVT = nvt.get_vmapped_logVT()
+    logVT = nvt.get_mapped_logVT()
 
     pmean_kwargs = poisson_mean_parser.poisson_mean_parser(args.pmean_json)
     erate_estimator = PoissonMean(logVT, KEY4, **pmean_kwargs)

--- a/src/kokab/n_spls_m_sgs/sage.py
+++ b/src/kokab/n_spls_m_sgs/sage.py
@@ -262,7 +262,7 @@ def main() -> None:
     nvt = vt_json_read_and_process(
         [param.name for param in parameters], args.vt_path, args.vt_json
     )
-    logVT = nvt.get_vmapped_logVT()
+    logVT = nvt.get_mapped_logVT()
 
     pmean_kwargs = poisson_mean_parser.poisson_mean_parser(args.pmean_json)
     erate_estimator = PoissonMean(logVT, KEY4, **pmean_kwargs)

--- a/src/kokab/one_powerlaw_one_peak/sage.py
+++ b/src/kokab/one_powerlaw_one_peak/sage.py
@@ -113,7 +113,7 @@ def main() -> None:
     nvt = vt_json_read_and_process(
         [param.name for param in parameters], args.vt_path, args.vt_json
     )
-    logVT = nvt.get_vmapped_logVT()
+    logVT = nvt.get_mapped_logVT()
 
     pmean_kwargs = poisson_mean_parser.poisson_mean_parser(args.pmean_json)
     erate_estimator = PoissonMean(logVT, KEY4, **pmean_kwargs)


### PR DESCRIPTION
We have used `jax.lax.map` to vectorize the logVT function to reduce the memory footprint. We have not provided any `batch_size` yet to see the effect of sequential execution of loops.