### PR TITLE
feat(gh-440): add memory profiling option to `flowMChandler.run` method

### DIFF
--- a/src/gwkokab/inference/flowMChandler.py
+++ b/src/gwkokab/inference/flowMChandler.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+import datetime
 from collections.abc import Callable
 from typing import Any, Optional
 
@@ -103,18 +105,24 @@ class flowMChandler(object):
             **self.sampler_kwargs,
         )
 
-    def run(self, debug_nans: bool = False) -> None:
+    def run(self, debug_nans: bool = False, profile_memory: bool = False) -> None:
         """Run the flowMC sampler and save the data.
 
         Parameters
         ----------
         debug_nans : bool, optional
             Whether to debug NaNs, by default False
+        profile_memory : bool, optional
+            Whether to profile memory, by default False
         """
         sampler = self.make_sampler()
         if debug_nans:
             with jax.debug_nans(True):
                 sampler.sample(self.initial_position, self.data)
+        if profile_memory:
+            time = datetime.datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+            sampler.sample(self.initial_position, self.data)
+            jax.profiler.save_device_memory_profile(f"gwkokab_memory_{time}.prof")
         else:
             sampler.sample(self.initial_position, self.data)
         save_data_from_sampler(sampler, **self.data_dump_kwargs)

--- a/src/kokab/chi_eff_q_relation/sage.py
+++ b/src/kokab/chi_eff_q_relation/sage.py
@@ -169,4 +169,4 @@ def main() -> None:
         **FLOWMC_HANDLER_KWARGS,
     )
 
-    handler.run(args.debug_nans)
+    handler.run(debug_nans=args.debug_nans, profile_memory=args.profile_memory)

--- a/src/kokab/ecc_matters/sage.py
+++ b/src/kokab/ecc_matters/sage.py
@@ -129,4 +129,4 @@ def main() -> None:
         **FLOWMC_HANDLER_KWARGS,
     )
 
-    handler.run(args.debug_nans)
+    handler.run(debug_nans=args.debug_nans, profile_memory=args.profile_memory)

--- a/src/kokab/n_pls_m_gs/sage.py
+++ b/src/kokab/n_pls_m_gs/sage.py
@@ -298,4 +298,4 @@ def main() -> None:
         **FLOWMC_HANDLER_KWARGS,
     )
 
-    handler.run(args.debug_nans)
+    handler.run(debug_nans=args.debug_nans, profile_memory=args.profile_memory)

--- a/src/kokab/n_spls_m_sgs/sage.py
+++ b/src/kokab/n_spls_m_sgs/sage.py
@@ -321,4 +321,4 @@ def main() -> None:
         **FLOWMC_HANDLER_KWARGS,
     )
 
-    handler.run(args.debug_nans)
+    handler.run(debug_nans=args.debug_nans, profile_memory=args.profile_memory)

--- a/src/kokab/one_powerlaw_one_peak/sage.py
+++ b/src/kokab/one_powerlaw_one_peak/sage.py
@@ -165,4 +165,4 @@ def main() -> None:
         **FLOWMC_HANDLER_KWARGS,
     )
 
-    handler.run(args.debug_nans)
+    handler.run(debug_nans=args.debug_nans, profile_memory=args.profile_memory)

--- a/src/kokab/utils/sage_parser.py
+++ b/src/kokab/utils/sage_parser.py
@@ -115,5 +115,10 @@ def get_parser(parser: ArgumentParser) -> ArgumentParser:
         "https://jax.readthedocs.io/en/latest/_autosummary/jax.debug_nans.html#jax.debug_nans.",
         action="store_true",
     )
+    debug_group.add_argument(
+        "--profile-memory",
+        help="Enable memory profiling.",
+        action="store_true",
+    )
 
     return parser


### PR DESCRIPTION
This PR contains the feature of profiling device memory. When enabled it will create a file with the name `gwkokab_memory_*.prof`, which can be viewed using pprof tools. For details see [JAX - Profiling device memory](https://docs.jax.dev/en/latest/device_memory_profiling.html).