### PR TITLE
refactor: remove redundant font setting from plotting scripts

### DIFF
--- a/src/cli_gwkokab/batch_scatter2d.py
+++ b/src/cli_gwkokab/batch_scatter2d.py
@@ -115,9 +115,7 @@ def main() -> None:
     parser = make_parser()
     args = parser.parse_args()
 
-    plt.rcParams.update(
-        {"text.usetex": args.use_latex, "font.family": "Times New Roman"}
-    )
+    plt.rcParams.update({"text.usetex": args.use_latex})
 
     file_list = glob.glob(args.data_regex)
 

--- a/src/cli_gwkokab/batch_scatter3d.py
+++ b/src/cli_gwkokab/batch_scatter3d.py
@@ -152,9 +152,7 @@ def main() -> None:
 
     file_list = glob.glob(args.data_regex)
 
-    plt.rcParams.update(
-        {"text.usetex": args.use_latex, "font.family": "Times New Roman"}
-    )
+    plt.rcParams.update({"text.usetex": args.use_latex})
 
     fig = plt.figure()
     ax = fig.add_subplot(111, projection="3d")

--- a/src/cli_gwkokab/chain_plot.py
+++ b/src/cli_gwkokab/chain_plot.py
@@ -108,9 +108,7 @@ def main() -> None:
     parser = make_parser()
     args = parser.parse_args()
 
-    plt.rcParams.update(
-        {"text.usetex": args.use_latex, "font.family": "Times New Roman"}
-    )
+    plt.rcParams.update({"text.usetex": args.use_latex})
 
     files = glob.glob(args.data_regex)
     n_dim = args.dimension

--- a/src/cli_gwkokab/corner_plot.py
+++ b/src/cli_gwkokab/corner_plot.py
@@ -129,9 +129,7 @@ def main() -> None:
     parser = make_parser()
     args = parser.parse_args()
 
-    plt.rcParams.update(
-        {"text.usetex": args.use_latex, "font.family": "Times New Roman"}
-    )
+    plt.rcParams.update({"text.usetex": args.use_latex})
     data = pd.read_csv(args.data.name, delimiter=" ", skiprows=1).to_numpy()
     figure = corner.corner(
         data,

--- a/src/cli_gwkokab/ess_plot.py
+++ b/src/cli_gwkokab/ess_plot.py
@@ -77,9 +77,7 @@ def main() -> None:
     parser = make_parser()
     args = parser.parse_args()
 
-    plt.rcParams.update(
-        {"text.usetex": args.use_latex, "font.family": "Times New Roman"}
-    )
+    plt.rcParams.update({"text.usetex": args.use_latex})
 
     train_paths = glob.glob(args.train_chain_regex)
     prod_paths = glob.glob(args.production_chain_regex)

--- a/src/cli_gwkokab/joint_plot.py
+++ b/src/cli_gwkokab/joint_plot.py
@@ -108,9 +108,7 @@ def main() -> None:
     parser = make_parser()
     args = parser.parse_args()
 
-    plt.rcParams.update(
-        {"text.usetex": args.use_latex, "font.family": "Times New Roman"}
-    )
+    plt.rcParams.update({"text.usetex": args.use_latex})
 
     data = pd.read_csv(args.data.name, delimiter=" ")
 

--- a/src/cli_gwkokab/ppd_plot.py
+++ b/src/cli_gwkokab/ppd_plot.py
@@ -134,9 +134,7 @@ def main() -> None:
     parser = make_parser()
     args = parser.parse_args()
 
-    plt.rcParams.update(
-        {"text.usetex": args.use_latex, "font.family": "Times New Roman"}
-    )
+    plt.rcParams.update({"text.usetex": args.use_latex})
 
     prefix = "" if args.prefix is None else args.prefix
 

--- a/src/cli_gwkokab/r_hat_plot.py
+++ b/src/cli_gwkokab/r_hat_plot.py
@@ -90,9 +90,7 @@ def main() -> None:
     parser = make_parser()
     args = parser.parse_args()
 
-    plt.rcParams.update(
-        {"text.usetex": args.use_latex, "font.family": "Times New Roman"}
-    )
+    plt.rcParams.update({"text.usetex": args.use_latex})
 
     chains_filenames = glob(args.chains_regex)
     chains = np.array([np.loadtxt(filename) for filename in chains_filenames])

--- a/src/cli_gwkokab/scatter2d.py
+++ b/src/cli_gwkokab/scatter2d.py
@@ -129,9 +129,7 @@ def main() -> None:
     parser = make_parser()
     args = parser.parse_args()
 
-    plt.rcParams.update(
-        {"text.usetex": args.use_latex, "font.family": "Times New Roman"}
-    )
+    plt.rcParams.update({"text.usetex": args.use_latex})
 
     if args.color:
         color = np.loadtxt(args.color)

--- a/src/cli_gwkokab/scatter3d.py
+++ b/src/cli_gwkokab/scatter3d.py
@@ -135,9 +135,7 @@ def main() -> None:
     parser = make_parser()
     args = parser.parse_args()
 
-    plt.rcParams.update(
-        {"text.usetex": args.use_latex, "font.family": "Times New Roman"}
-    )
+    plt.rcParams.update({"text.usetex": args.use_latex})
 
     data = pd.read_csv(args.data.name, delimiter=" ")
     x = data[args.x_value_column_name].to_numpy()


### PR DESCRIPTION
Many work machines do not have special fonts. This PR avoids being too fancy.