### PR TITLE
refactor(gh-460): Serializing ppd generation to avoid batched models

### DIFF
--- a/src/kokab/n_pls_m_gs/ppd.py
+++ b/src/kokab/n_pls_m_gs/ppd.py
@@ -13,12 +13,9 @@
 # limitations under the License.
 
 
-import json
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
-from typing_extensions import Callable, Dict, List, Tuple, Union
 
 import pandas as pd
-from jaxtyping import Array
 
 import gwkokab
 from gwkokab.models import NPowerlawMGaussian
@@ -32,7 +29,9 @@ from gwkokab.parameters import (
     SECONDARY_MASS_SOURCE,
     SECONDARY_SPIN_MAGNITUDE,
 )
+from gwkokab.utils.tools import error_if
 from kokab.utils import ppd, ppd_parser
+from kokab.utils.common import read_json
 
 
 def make_parser() -> ArgumentParser:
@@ -49,60 +48,6 @@ def make_parser() -> ArgumentParser:
     return parser
 
 
-def load_configuration(
-    constants_file: str, nf_samples_mapping_file: str
-) -> Tuple[
-    Dict[str, Union[int, float, bool]],
-    Dict[str, int],
-]:
-    try:
-        with open(constants_file, "r") as f:
-            constants: Dict[str, Union[int, float, bool]] = json.load(f)
-        with open(nf_samples_mapping_file, "r") as f:
-            nf_samples_mapping: Dict[str, int] = json.load(f)
-        return constants, nf_samples_mapping
-    except (FileNotFoundError, json.JSONDecodeError) as e:
-        raise ValueError(f"Error loading configuration: {e}")
-
-
-def get_model_pdf(
-    constants: Dict[str, Union[int, float, bool]],
-    nf_samples_mapping: Dict[str, int],
-    rate_scaled: bool = False,
-) -> Callable[[Array], Array]:
-    nf_samples = pd.read_csv(
-        "sampler_data/nf_samples.dat", delimiter=" ", skiprows=1
-    ).to_numpy()
-
-    if not rate_scaled:
-        model = NPowerlawMGaussian(
-            **constants,
-            **{
-                name: (nf_samples[..., i] if not name.startswith("log_rate") else 0.0)
-                for name, i in nf_samples_mapping.items()
-            },
-        )
-    else:
-        model = NPowerlawMGaussian(
-            **constants,
-            **{name: nf_samples[..., i] for name, i in nf_samples_mapping.items()},
-        )
-
-    return model.log_prob
-
-
-def compute_and_save_ppd(
-    logpdf: Callable[[Array], Array],
-    domains: List[Tuple[float, float, int]],
-    output_file: str,
-    parameters: List[str],
-) -> None:
-    prob_values = ppd.compute_probs(logpdf, domains)
-    ppd_values = ppd.get_ppd(prob_values, axis=-1)
-    marginals = ppd.get_all_marginals(prob_values, domains)
-    ppd.save_probs(ppd_values, marginals, output_file, domains, parameters)
-
-
 def main() -> None:
     parser = make_parser()
     args = parser.parse_args()
@@ -112,12 +57,13 @@ def main() -> None:
             create_truncated_normal_distributions
         )
 
-    if not str(args.filename).endswith(".hdf5"):
-        raise ValueError("Output file must be an HDF5 file.")
-
-    constants, nf_samples_mapping = load_configuration(
-        args.constants, args.nf_samples_mapping
+    error_if(
+        not str(args.filename).endswith(".hdf5"),
+        "Output file must be an HDF5 file.",
     )
+
+    constants = read_json(args.constants)
+    nf_samples_mapping = read_json(args.nf_samples_mapping)
 
     has_spin = constants.get("use_spin", False)
     has_tilt = constants.get("use_tilt", False)
@@ -131,10 +77,26 @@ def main() -> None:
     if has_eccentricity:
         parameters.append(ECCENTRICITY.name)
 
-    model_without_rate_pdf = get_model_pdf(constants, nf_samples_mapping)
-    compute_and_save_ppd(model_without_rate_pdf, args.range, args.filename, parameters)
+    nf_samples = pd.read_csv("sampler_data/nf_samples.dat", delimiter=" ").to_numpy()
 
-    model_with_rate_pdf = get_model_pdf(constants, nf_samples_mapping, rate_scaled=True)
-    compute_and_save_ppd(
-        model_with_rate_pdf, args.range, "rate_scaled_" + args.filename, parameters
+    ppd.compute_and_save_ppd(
+        NPowerlawMGaussian,
+        nf_samples,
+        args.range,
+        "rate_scaled_" + args.filename,
+        parameters,
+        constants,
+        nf_samples_mapping,
+    )
+
+    nf_samples, constants = ppd.wipe_log_rate(nf_samples, nf_samples_mapping, constants)
+
+    ppd.compute_and_save_ppd(
+        NPowerlawMGaussian,
+        nf_samples,
+        args.range,
+        args.filename,
+        parameters,
+        constants,
+        nf_samples_mapping,
     )

--- a/src/kokab/n_spls_m_sgs/ppd.py
+++ b/src/kokab/n_spls_m_sgs/ppd.py
@@ -13,12 +13,9 @@
 # limitations under the License.
 
 
-import json
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
-from typing_extensions import Callable, Dict, List, Tuple, Union
 
 import pandas as pd
-from jaxtyping import Array
 
 import gwkokab
 from gwkokab.models import NSmoothedPowerlawMSmoothedGaussian
@@ -37,7 +34,9 @@ from gwkokab.parameters import (
     SECONDARY_MASS_SOURCE,
     SECONDARY_SPIN_MAGNITUDE,
 )
+from gwkokab.utils.tools import error_if
 from kokab.utils import ppd, ppd_parser
+from kokab.utils.common import read_json
 
 
 def make_parser() -> ArgumentParser:
@@ -61,60 +60,6 @@ def make_parser() -> ArgumentParser:
     return parser
 
 
-def load_configuration(
-    constants_file: str, nf_samples_mapping_file: str
-) -> Tuple[
-    Dict[str, Union[int, float, bool]],
-    Dict[str, int],
-]:
-    try:
-        with open(constants_file, "r") as f:
-            constants: Dict[str, Union[int, float, bool]] = json.load(f)
-        with open(nf_samples_mapping_file, "r") as f:
-            nf_samples_mapping: Dict[str, int] = json.load(f)
-        return constants, nf_samples_mapping
-    except (FileNotFoundError, json.JSONDecodeError) as e:
-        raise ValueError(f"Error loading configuration: {e}")
-
-
-def get_model_pdf(
-    constants: Dict[str, Union[int, float, bool]],
-    nf_samples_mapping: Dict[str, int],
-    rate_scaled: bool = False,
-) -> Callable[[Array], Array]:
-    nf_samples = pd.read_csv(
-        "sampler_data/nf_samples.dat", delimiter=" ", skiprows=1
-    ).to_numpy()
-
-    if not rate_scaled:
-        model = NSmoothedPowerlawMSmoothedGaussian(
-            **constants,
-            **{
-                name: (nf_samples[..., i] if not name.startswith("log_rate") else 0.0)
-                for name, i in nf_samples_mapping.items()
-            },
-        )
-    else:
-        model = NSmoothedPowerlawMSmoothedGaussian(
-            **constants,
-            **{name: nf_samples[..., i] for name, i in nf_samples_mapping.items()},
-        )
-
-    return model.log_prob
-
-
-def compute_and_save_ppd(
-    logpdf: Callable[[Array], Array],
-    domains: List[Tuple[float, float, int]],
-    output_file: str,
-    parameters: List[str],
-) -> None:
-    prob_values = ppd.compute_probs(logpdf, domains)
-    ppd_values = ppd.get_ppd(prob_values, axis=-1)
-    marginals = ppd.get_all_marginals(prob_values, domains)
-    ppd.save_probs(ppd_values, marginals, output_file, domains, parameters)
-
-
 def main() -> None:
     parser = make_parser()
     args = parser.parse_args()
@@ -122,12 +67,13 @@ def main() -> None:
     if args.spin_truncated_normal:
         gwkokab.models.nsmoothedpowerlawmsmoothedgaussian._model.build_spin_distributions = create_truncated_normal_distributions
 
-    if not str(args.filename).endswith(".hdf5"):
-        raise ValueError("Output file must be an HDF5 file.")
-
-    constants, nf_samples_mapping = load_configuration(
-        args.constants, args.nf_samples_mapping
+    error_if(
+        not str(args.filename).endswith(".hdf5"),
+        "Output file must be an HDF5 file.",
     )
+
+    constants = read_json(args.constants)
+    nf_samples_mapping = read_json(args.nf_samples_mapping)
 
     has_spin = constants.get("use_spin", False)
     has_tilt = constants.get("use_tilt", False)
@@ -147,10 +93,26 @@ def main() -> None:
     if has_eccentricity:
         parameters.append(ECCENTRICITY.name)
 
-    model_without_rate_pdf = get_model_pdf(constants, nf_samples_mapping)
-    compute_and_save_ppd(model_without_rate_pdf, args.range, args.filename, parameters)
+    nf_samples = pd.read_csv("sampler_data/nf_samples.dat", delimiter=" ").to_numpy()
 
-    model_with_rate_pdf = get_model_pdf(constants, nf_samples_mapping, rate_scaled=True)
-    compute_and_save_ppd(
-        model_with_rate_pdf, args.range, "rate_scaled_" + args.filename, parameters
+    ppd.compute_and_save_ppd(
+        NSmoothedPowerlawMSmoothedGaussian,
+        nf_samples,
+        args.range,
+        "rate_scaled_" + args.filename,
+        parameters,
+        constants,
+        nf_samples_mapping,
+    )
+
+    nf_samples, constants = ppd.wipe_log_rate(nf_samples, nf_samples_mapping, constants)
+
+    ppd.compute_and_save_ppd(
+        NSmoothedPowerlawMSmoothedGaussian,
+        nf_samples,
+        args.range,
+        args.filename,
+        parameters,
+        constants,
+        nf_samples_mapping,
     )

--- a/src/kokab/utils/common.py
+++ b/src/kokab/utils/common.py
@@ -40,9 +40,17 @@ def read_json(json_file: str) -> dict:
     -------
     dict
         json file content as dict
+
+    Raises
+    ------
+    ValueError
+        If the file is not found or if the file is not a valid json file
     """
-    with open(json_file, "r") as f:
-        content = json.load(f)
+    try:
+        with open(json_file, "r") as f:
+            content = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        raise ValueError(f"Error loading configuration: {e}")
     return content
 
 


### PR DESCRIPTION
We have to handle the special case of batched models only to generate ppd. We can simplify their implementation if we do sequential generation of ppd instead of vmaped.

Closes #460