### PR TITLE
fix: expand `pytree_data_fields` in distribution models for improved pytree flattening

### DIFF
--- a/src/gwkokab/models/_models.py
+++ b/src/gwkokab/models/_models.py
@@ -77,7 +77,7 @@ class PowerlawPrimaryMassRatio(Distribution):
         "mmax": constraints.positive,
     }
     reparametrized_params = ["alpha", "beta", "mmin", "mmax"]
-    pytree_data_fields = ("_support",)
+    pytree_data_fields = ("_support", "alpha", "beta", "mmax", "mmin")
 
     def __init__(
         self,
@@ -167,7 +167,7 @@ class Wysocki2019MassModel(Distribution):
         "mmax": constraints.positive,
     }
     reparametrized_params = ["alpha_m", "mmin", "mmax"]
-    pytree_data_fields = ("_support",)
+    pytree_data_fields = ("_support", "alpha_m", "mmax", "mmin")
 
     def __init__(
         self,
@@ -646,7 +646,16 @@ class SmoothedPowerlawPrimaryMassRatio(Distribution):
         "delta": constraints.positive,
     }
     reparametrized_params = ["alpha", "beta", "mmin", "mmax", "delta"]
-    pytree_data_fields = ("_support", "_logZ", "_Z_q_given_m1")
+    pytree_data_fields = (
+        "_logZ",
+        "_support",
+        "_Z_q_given_m1",
+        "alpha",
+        "beta",
+        "delta",
+        "mmax",
+        "mmin",
+    )
 
     def __init__(
         self,
@@ -805,7 +814,17 @@ class SmoothedGaussianPrimaryMassRatio(Distribution):
         "delta": constraints.positive,
     }
     reparametrized_params = ["loc", "scale", "beta", "mmin", "mmax", "delta"]
-    pytree_data_fields = ("_support", "_logZ", "_Z_q_given_m1")
+    pytree_data_fields = (
+        "_logZ",
+        "_support",
+        "_Z_q_given_m1",
+        "beta",
+        "delta",
+        "loc",
+        "mmax",
+        "mmin",
+        "scale",
+    )
 
     def __init__(
         self, loc, scale, beta, mmin, mmax, delta, *, validate_args=None

--- a/src/gwkokab/models/multivariate/_chi_eff_mass_ratio.py
+++ b/src/gwkokab/models/multivariate/_chi_eff_mass_ratio.py
@@ -141,8 +141,19 @@ class ChiEffMassRatioCorrelated(Distribution):
         "kappa",
     ]
     pytree_data_fields = (
-        # "_z_powerlaw",
         "_support",
+        "alpha",
+        "beta",
+        "gamma",
+        "kappa",
+        "lamb",
+        "lambda_peak",
+        "loc_m",
+        "log10_sigma_eff_0",
+        "mmax",
+        "mmin",
+        "mu_eff_0",
+        "scale_m",
     )
 
     def __init__(


### PR DESCRIPTION
We were missing some attributes in `pytree_data_field`, causing `tests/test_distributions.py::test_dist_pytree` were failing.