### PR TITLE
feat(gh-135): extends `SmoothedPowerlawAndPeak` with `PowerlawRedshift`

### DIFF
--- a/src/gwkokab/models/__init__.py
+++ b/src/gwkokab/models/__init__.py
@@ -39,6 +39,7 @@ from .npowerlawmgaussian import NPowerlawMGaussian as NPowerlawMGaussian
 from .nsmoothedpowerlawmsmoothedgaussian import (
     NSmoothedPowerlawMSmoothedGaussian as NSmoothedPowerlawMSmoothedGaussian,
     SmoothedPowerlawAndPeak as SmoothedPowerlawAndPeak,
+    SmoothedPowerlawPeakAndPowerlawRedshift as SmoothedPowerlawPeakAndPowerlawRedshift,
 )
 from .redshift import PowerlawRedshift as PowerlawRedshift
 from .spin import (

--- a/src/gwkokab/models/nsmoothedpowerlawmsmoothedgaussian/__init__.py
+++ b/src/gwkokab/models/nsmoothedpowerlawmsmoothedgaussian/__init__.py
@@ -16,4 +16,5 @@
 from ._model import (
     NSmoothedPowerlawMSmoothedGaussian as NSmoothedPowerlawMSmoothedGaussian,
     SmoothedPowerlawAndPeak as SmoothedPowerlawAndPeak,
+    SmoothedPowerlawPeakAndPowerlawRedshift as SmoothedPowerlawPeakAndPowerlawRedshift,
 )

--- a/src/gwkokab/models/utils/_joindistribution.py
+++ b/src/gwkokab/models/utils/_joindistribution.py
@@ -48,7 +48,7 @@ class JointDistribution(Distribution):
         """
         if not marginal_distributions:
             raise ValueError("At least one marginal distribution is required.")
-        self.marginal_distributions = marginal_distributions
+        self.marginal_distributions = list(marginal_distributions)
         self.shaped_values: Tuple[int | slice, ...] = tuple()
         batch_shape = lax.broadcast_shapes(
             *tuple(d.batch_shape for d in self.marginal_distributions)

--- a/src/gwkokab/vts/_neuralvt.py
+++ b/src/gwkokab/vts/_neuralvt.py
@@ -52,10 +52,15 @@ class NeuralNetVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
             raise TypeError(f"parameters must be a Sequence, got {type(parameters)}")
         if not all(isinstance(p, str) for p in parameters):
             raise TypeError("all parameters must be strings")
-        if not isinstance(batch_size, int):
-            raise TypeError(f"batch_size must be an integer, got {type(batch_size)}")
-        if batch_size < 1:
-            raise ValueError(f"batch_size must be a positive integer, got {batch_size}")
+        if batch_size is not None:
+            if not isinstance(batch_size, int):
+                raise TypeError(
+                    f"batch_size must be an integer, got {type(batch_size)}"
+                )
+            if batch_size < 1:
+                raise ValueError(
+                    f"batch_size must be a positive integer, got {batch_size}"
+                )
 
         self.batch_size = batch_size
         names, self.neural_vt_model = load_model(filename)

--- a/src/gwkokab/vts/_popmodelvt.py
+++ b/src/gwkokab/vts/_popmodelvt.py
@@ -95,10 +95,15 @@ class PopModelsVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
         batch_size : Optional[int], optional
             The batch size :func:`jax.lax.map` should use, by default None.
         """
-        if not isinstance(batch_size, int):
-            raise TypeError(f"batch_size must be an integer, got {type(batch_size)}")
-        if batch_size < 1:
-            raise ValueError(f"batch_size must be a positive integer, got {batch_size}")
+        if batch_size is not None:
+            if not isinstance(batch_size, int):
+                raise TypeError(
+                    f"batch_size must be an integer, got {type(batch_size)}"
+                )
+            if batch_size < 1:
+                raise ValueError(
+                    f"batch_size must be a positive integer, got {batch_size}"
+                )
 
         self.batch_size = batch_size
         self.m_min = m_min

--- a/src/kokab/chi_eff_q_relation/sage.py
+++ b/src/kokab/chi_eff_q_relation/sage.py
@@ -129,7 +129,9 @@ def main() -> None:
     erate_estimator = PoissonMean(logVT, key=KEY4, **pmean_kwargs)
 
     data = get_posterior_data(glob(POSTERIOR_REGEX), POSTERIOR_COLUMNS)
-    log_ref_priors = [jax.device_put(REDSHIFT.prior.log_prob(d[..., 4])) for d in data]
+    log_ref_priors = jax.device_put(
+        [REDSHIFT.prior.log_prob(d[..., 4]) for d in data], may_alias=True
+    )
 
     poisson_likelihood = PoissonLikelihood(
         model=model,

--- a/src/kokab/ecc_matters/sage.py
+++ b/src/kokab/ecc_matters/sage.py
@@ -89,7 +89,9 @@ def main() -> None:
     erate_estimator = PoissonMean(logVT, key=KEY4, **pmean_kwargs)
 
     data = get_posterior_data(glob(POSTERIOR_REGEX), POSTERIOR_COLUMNS)
-    log_ref_priors = [jax.device_put(np.zeros(d.shape[:-1])) for d in data]
+    log_ref_priors = jax.device_put(
+        [np.zeros(d.shape[:-1]) for d in data], may_alias=True
+    )
 
     poisson_likelihood = PoissonLikelihood(
         model=model,

--- a/src/kokab/n_pls_m_gs/sage.py
+++ b/src/kokab/n_pls_m_gs/sage.py
@@ -252,7 +252,9 @@ def main() -> None:
     erate_estimator = PoissonMean(logVT, key=KEY4, **pmean_kwargs)
 
     data = get_posterior_data(glob(POSTERIOR_REGEX), POSTERIOR_COLUMNS)
-    log_ref_priors = [jax.device_put(np.zeros(d.shape[:-1])) for d in data]
+    log_ref_priors = jax.device_put(
+        [np.zeros(d.shape[:-1]) for d in data], may_alias=True
+    )
 
     poisson_likelihood = PoissonLikelihood(
         model=model,

--- a/src/kokab/n_spls_m_sgs/sage.py
+++ b/src/kokab/n_spls_m_sgs/sage.py
@@ -274,7 +274,9 @@ def main() -> None:
     erate_estimator = PoissonMean(logVT, key=KEY4, **pmean_kwargs)
 
     data = get_posterior_data(glob(POSTERIOR_REGEX), POSTERIOR_COLUMNS)
-    log_ref_priors = [jax.device_put(np.zeros(d.shape[:-1])) for d in data]
+    log_ref_priors = jax.device_put(
+        [np.zeros(d.shape[:-1]) for d in data], may_alias=True
+    )
 
     poisson_likelihood = PoissonLikelihood(
         model=model,

--- a/src/kokab/one_powerlaw_one_peak/ppd.py
+++ b/src/kokab/one_powerlaw_one_peak/ppd.py
@@ -49,8 +49,8 @@ def model(**params) -> DistributionLike:
     _model._component_distributions[0].marginal_distributions[0] = (
         _model._component_distributions[0].marginal_distributions[0].base_dist
     )
-    _model._component_distributions[1].marginal_distributions[1] = (
-        _model._component_distributions[1].marginal_distributions[1].base_dist
+    _model._component_distributions[1].marginal_distributions[0] = (
+        _model._component_distributions[1].marginal_distributions[0].base_dist
     )
     return _model
 

--- a/src/kokab/one_powerlaw_one_peak/ppd.py
+++ b/src/kokab/one_powerlaw_one_peak/ppd.py
@@ -16,11 +16,10 @@
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 
 import pandas as pd
-from numpyro.distributions import TransformedDistribution
+from numpyro.distributions.distribution import DistributionLike
 
-from gwkokab.models import SmoothedPowerlawAndPeak
-from gwkokab.models.transformations import ComponentMassesToPrimaryMassAndMassRatio
-from gwkokab.parameters import PRIMARY_MASS_SOURCE, SECONDARY_MASS_SOURCE
+from gwkokab.models import SmoothedPowerlawPeakAndPowerlawRedshift
+from gwkokab.parameters import PRIMARY_MASS_SOURCE, REDSHIFT, SECONDARY_MASS_SOURCE
 from gwkokab.utils.tools import error_if
 from kokab.utils import ppd, ppd_parser
 from kokab.utils.common import read_json
@@ -42,13 +41,18 @@ def make_parser() -> ArgumentParser:
     return parser
 
 
-def model(**params) -> TransformedDistribution:
+def model(**params) -> DistributionLike:
     validate_args = params.pop("validate_args", True)
-    return TransformedDistribution(
-        SmoothedPowerlawAndPeak(**params, validate_args=validate_args),
-        transforms=ComponentMassesToPrimaryMassAndMassRatio(),
-        validate_args=validate_args,
+    _model = SmoothedPowerlawPeakAndPowerlawRedshift(
+        **params, validate_args=validate_args
     )
+    _model._component_distributions[0].marginal_distributions[0] = (
+        _model._component_distributions[0].marginal_distributions[0].base_dist
+    )
+    _model._component_distributions[1].marginal_distributions[1] = (
+        _model._component_distributions[1].marginal_distributions[1].base_dist
+    )
+    return _model
 
 
 def main() -> None:
@@ -63,7 +67,7 @@ def main() -> None:
     constants = read_json(args.constants)
     nf_samples_mapping = read_json(args.nf_samples_mapping)
 
-    parameters = [PRIMARY_MASS_SOURCE.name, SECONDARY_MASS_SOURCE.name]
+    parameters = [PRIMARY_MASS_SOURCE.name, SECONDARY_MASS_SOURCE.name, REDSHIFT.name]
 
     nf_samples = pd.read_csv("sampler_data/nf_samples.dat", delimiter=" ").to_numpy()
 

--- a/src/kokab/one_powerlaw_one_peak/sage.py
+++ b/src/kokab/one_powerlaw_one_peak/sage.py
@@ -104,7 +104,9 @@ def main() -> None:
     erate_estimator = PoissonMean(logVT, key=KEY4, **pmean_kwargs)
 
     data = get_posterior_data(glob(POSTERIOR_REGEX), POSTERIOR_COLUMNS)
-    log_ref_priors = [jax.device_put(np.zeros(d.shape[:-1])) for d in data]
+    log_ref_priors = jax.device_put(
+        [np.zeros(d.shape[:-1]) for d in data], may_alias=True
+    )
 
     poisson_likelihood = PoissonLikelihood(
         model=model,

--- a/src/kokab/one_powerlaw_one_peak/sage.py
+++ b/src/kokab/one_powerlaw_one_peak/sage.py
@@ -27,11 +27,8 @@ from gwkokab.inference import (
     PoissonLikelihood,
 )
 from gwkokab.logger import enable_logging
-from gwkokab.models import SmoothedPowerlawAndPeak
-from gwkokab.parameters import (
-    PRIMARY_MASS_SOURCE,
-    SECONDARY_MASS_SOURCE,
-)
+from gwkokab.models import SmoothedPowerlawPeakAndPowerlawRedshift
+from gwkokab.parameters import PRIMARY_MASS_SOURCE, REDSHIFT, SECONDARY_MASS_SOURCE
 from gwkokab.poisson_mean import PoissonMean
 from gwkokab.utils.tools import error_if
 from kokab.utils import poisson_mean_parser, sage_parser
@@ -76,16 +73,18 @@ def main() -> None:
     model_parameters = [
         "alpha",
         "beta",
-        "loc",
-        "scale",
-        "mmin",
-        "mmax",
         "delta",
+        "lamb",
         "lambda_peak",
+        "loc",
         "log_rate",
+        "mmax",
+        "mmin",
+        "scale",
+        "z_max",
     ]
 
-    parameters = [PRIMARY_MASS_SOURCE, SECONDARY_MASS_SOURCE]
+    parameters = [PRIMARY_MASS_SOURCE, SECONDARY_MASS_SOURCE, REDSHIFT]
     error_if(
         set(POSTERIOR_COLUMNS) != set(map(lambda p: p.name, parameters)),
         "The parameters in the posterior data do not match the parameters in the model.",
@@ -93,7 +92,7 @@ def main() -> None:
 
     model_prior_param = get_processed_priors(model_parameters, prior_dict)
 
-    model = Bake(SmoothedPowerlawAndPeak)(**model_prior_param)
+    model = Bake(SmoothedPowerlawPeakAndPowerlawRedshift)(**model_prior_param)
 
     nvt = vt_json_read_and_process(
         [param.name for param in parameters], args.vt_path, args.vt_json

--- a/src/kokab/utils/common.py
+++ b/src/kokab/utils/common.py
@@ -126,8 +126,9 @@ def get_posterior_data(
             raise KeyError(
                 f"The file '{event}' is missing required columns: {missing_columns}"
             )
-        data = jax.device_put(df[posterior_columns].to_numpy())
+        data = df[posterior_columns].to_numpy()
         data_list.append(data)
+    data_list = jax.device_put(data_list, may_alias=True)
     return data_list
 
 


### PR DESCRIPTION
## Summary

This PR introduces the required redshift model in Single Powerlaw and Peak.

## Related Issues

- #135

## Detailed Description

GWTC-3 paper analyzes Single powerlaw and peak, which is incomplete without the joining powerlaw redshift model. We have created a separate implementation for this model named `SmoothedPowerlawPeakAndPowerlawRedshift`, with hardcoded Plank 2015 Cosmology.