### PR TITLE
chore(deps): pin flowMC dependency to version 0.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ classifiers = [
 dependencies = [
     "arviz>=0.20.0",
     "chex>=0.1.87",
-    "flowMC>=0.3.4",
+    "flowMC==0.3.4",
     "h5py>=3.12.1",
     "interpax>=0.3.5",
     "jax>=0.4.30",


### PR DESCRIPTION
A recent update (https://github.com/kazewong/flowMC/pull/189) in flowMC has many breaking changes. It is said to be released in the upcoming weeks (ref: https://github.com/kazewong/flowMC/pull/185#issuecomment-2676215357). We are constraining the version to the latest one and will later deal with the new breaking changes coming with flowMC.