### PR TITLE
refactor: redundant `vt-path` argument from VT options in parsers

### DIFF
--- a/src/kokab/chi_eff_q_relation/sage.py
+++ b/src/kokab/chi_eff_q_relation/sage.py
@@ -121,9 +121,7 @@ def main() -> None:
         "The parameters in the posterior data do not match the parameters in the model.",
     )
 
-    nvt = vt_json_read_and_process(
-        [param.name for param in parameters], args.vt_path, args.vt_json
-    )
+    nvt = vt_json_read_and_process([param.name for param in parameters], args.vt_json)
     logVT = nvt.get_mapped_logVT()
 
     pmean_kwargs = poisson_mean_parser.poisson_mean_parser(args.pmean_json)

--- a/src/kokab/ecc_matters/genie.py
+++ b/src/kokab/ecc_matters/genie.py
@@ -123,7 +123,7 @@ def main() -> None:
 
     model_parameters = [m1_source, m2_source, ecc]
 
-    nvt = vt_json_read_and_process(model_parameters, args.vt_path, args.vt_json)
+    nvt = vt_json_read_and_process(model_parameters, args.vt_json)
     logVT = nvt.get_mapped_logVT()
 
     pmean_kwargs = poisson_mean_parser.poisson_mean_parser(args.pmean_json)

--- a/src/kokab/ecc_matters/sage.py
+++ b/src/kokab/ecc_matters/sage.py
@@ -81,9 +81,7 @@ def main() -> None:
         "The parameters in the posterior data do not match the parameters in the model.",
     )
 
-    nvt = vt_json_read_and_process(
-        [param.name for param in parameters], args.vt_path, args.vt_json
-    )
+    nvt = vt_json_read_and_process([param.name for param in parameters], args.vt_json)
     logVT = nvt.get_mapped_logVT()
 
     pmean_kwargs = poisson_mean_parser.poisson_mean_parser(args.pmean_json)

--- a/src/kokab/n_pls_m_gs/genie.py
+++ b/src/kokab/n_pls_m_gs/genie.py
@@ -359,7 +359,7 @@ def main() -> None:
         has_redshift=has_redshift,
     )
 
-    nvt = vt_json_read_and_process(parameters_name, args.vt_path, args.vt_json)
+    nvt = vt_json_read_and_process(parameters_name, args.vt_json)
     logVT = nvt.get_mapped_logVT()
 
     pmean_kwargs = poisson_mean_parser.poisson_mean_parser(args.pmean_json)

--- a/src/kokab/n_pls_m_gs/sage.py
+++ b/src/kokab/n_pls_m_gs/sage.py
@@ -244,9 +244,7 @@ def main() -> None:
         **model_prior_param,
     )
 
-    nvt = vt_json_read_and_process(
-        [param.name for param in parameters], args.vt_path, args.vt_json
-    )
+    nvt = vt_json_read_and_process([param.name for param in parameters], args.vt_json)
     logVT = nvt.get_mapped_logVT()
 
     pmean_kwargs = poisson_mean_parser.poisson_mean_parser(args.pmean_json)

--- a/src/kokab/n_spls_m_sgs/sage.py
+++ b/src/kokab/n_spls_m_sgs/sage.py
@@ -262,9 +262,7 @@ def main() -> None:
         **model_prior_param,
     )
 
-    nvt = vt_json_read_and_process(
-        [param.name for param in parameters], args.vt_path, args.vt_json
-    )
+    nvt = vt_json_read_and_process([param.name for param in parameters], args.vt_json)
     logVT = nvt.get_mapped_logVT()
 
     pmean_kwargs = poisson_mean_parser.poisson_mean_parser(args.pmean_json)

--- a/src/kokab/one_powerlaw_one_peak/sage.py
+++ b/src/kokab/one_powerlaw_one_peak/sage.py
@@ -92,9 +92,7 @@ def main() -> None:
 
     model = Bake(SmoothedPowerlawPeakAndPowerlawRedshift)(**model_prior_param)
 
-    nvt = vt_json_read_and_process(
-        [param.name for param in parameters], args.vt_path, args.vt_json
-    )
+    nvt = vt_json_read_and_process([param.name for param in parameters], args.vt_json)
     logVT = nvt.get_mapped_logVT()
 
     pmean_kwargs = poisson_mean_parser.poisson_mean_parser(args.pmean_json)

--- a/src/kokab/utils/common.py
+++ b/src/kokab/utils/common.py
@@ -16,7 +16,7 @@
 import json
 import warnings
 from collections.abc import Sequence
-from typing import List, Union
+from typing import Dict, List, Union
 
 import jax
 import numpy as np
@@ -185,23 +185,29 @@ def check_vt_params(vt_params: List[str], parameters: List[str]) -> None:
 
 
 def vt_json_read_and_process(
-    parameters: Sequence[str], vt_path: str, settings_path: str
+    parameters: Sequence[str], settings_path: str
 ) -> VolumeTimeSensitivityInterface:
-    r"""Read and process the VT JSON file.
+    """Read and process the VT JSON file.
 
-    :param parameters: list of parameters
-    :param vt_path: path to the VT
-    :param settings_path: path to the VT settings
-    :raises ValueError: if the VT is not found
-    :return: VT object
+    Parameters
+    ----------
+    parameters : Sequence[str]
+        list of parameters
+    settings_path : str
+        path to the VT settings
+
+    Returns
+    -------
+    VolumeTimeSensitivityInterface
+        VT object
     """
     with open(settings_path, "r") as f:
-        vt_settings = json.load(f)
+        vt_settings: Dict = json.load(f)
 
-    vt_type = vt_settings["type"]
-    vt_settings.pop("type")
+    vt_type = vt_settings.pop("type")
+    vt_path = vt_settings.pop("filename")
     vt = available_vts[vt_type]
-    return vt(parameters, vt_path, **vt_settings)
+    return vt(parameters=parameters, filename=vt_path, **vt_settings)
 
 
 def get_dist(meta_dict: dict[str, Union[str, float]]) -> DistributionLike:

--- a/src/kokab/utils/genie_parser.py
+++ b/src/kokab/utils/genie_parser.py
@@ -47,12 +47,6 @@ def get_parser(parser: ArgumentParser) -> ArgumentParser:
     vt_group = parser.add_argument_group("VT Options")
 
     vt_group.add_argument(
-        "--vt-path",
-        help="Path to the neural VT",
-        type=str,
-        required=True,
-    )
-    vt_group.add_argument(
         "--vt-json",
         help="Path to the JSON file containing the VT options.",
         type=str,

--- a/src/kokab/utils/sage_parser.py
+++ b/src/kokab/utils/sage_parser.py
@@ -58,12 +58,6 @@ def get_parser(parser: ArgumentParser) -> ArgumentParser:
     vt_group = parser.add_argument_group("VT Options")
 
     vt_group.add_argument(
-        "--vt-path",
-        help="Path to the neural VT",
-        type=str,
-        required=True,
-    )
-    vt_group.add_argument(
         "--vt-json",
         help="Path to the JSON file containing the VT options.",
         type=str,


### PR DESCRIPTION
## Summary

Remove `--vt-path` argument for the sage and genie parser, now it will be provided in the `vt.json`