### PR TITLE
refactor: replace `typing_extensions` imports with standard `typing` imports

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -148,7 +148,6 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "numpyro": ("https://num.pyro.ai/en/stable/", None),
     "python": ("https://docs.python.org/3/", None),
-    "typing_extensions": ("https://typing-extensions.readthedocs.io/en/latest/", None),
     "chex": ("https://chex.readthedocs.io/en/latest/", None),
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dependencies = [
     "rich>=13.9.4",
     "RIFT>=0.0.15.11",
     "seaborn>=0.13.0",
-    "typing_extensions>=4.12.0",
 ]
 keywords = [
     "astrophysics",

--- a/ruff.toml
+++ b/ruff.toml
@@ -58,6 +58,6 @@ docstring-code-line-length = "dynamic"
 
 [lint.isort]
 combine-as-imports = true
-extra-standard-library = ["typing_extensions"]
+extra-standard-library = []
 lines-after-imports = 2
 order-by-type = false

--- a/src/cli_gwkokab/ppd_plot.py
+++ b/src/cli_gwkokab/ppd_plot.py
@@ -14,7 +14,7 @@
 
 
 import argparse
-from typing_extensions import Any, List, Tuple
+from typing import Any, List, Tuple
 
 import h5py
 import numpy as np

--- a/src/gwkokab/models/_models.py
+++ b/src/gwkokab/models/_models.py
@@ -14,7 +14,7 @@
 
 
 from functools import partial
-from typing_extensions import Optional
+from typing import Optional
 
 import chex
 import interpax

--- a/src/gwkokab/models/npowerlawmgaussian/_model.py
+++ b/src/gwkokab/models/npowerlawmgaussian/_model.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing_extensions import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 from jax import numpy as jnp, tree as jtr
 from jaxtyping import Array

--- a/src/gwkokab/models/nsmoothedpowerlawmsmoothedgaussian/_model.py
+++ b/src/gwkokab/models/nsmoothedpowerlawmsmoothedgaussian/_model.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing_extensions import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 from jax import numpy as jnp
 from jaxtyping import Array, ArrayLike

--- a/src/gwkokab/models/utils/_joindistribution.py
+++ b/src/gwkokab/models/utils/_joindistribution.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 
-from typing import Optional
-from typing_extensions import Tuple
+from typing import Optional, Tuple
 
 from jax import lax, numpy as jnp, random as jrd
 from jaxtyping import Array, PRNGKeyArray

--- a/src/gwkokab/models/utils/_ncombination.py
+++ b/src/gwkokab/models/utils/_ncombination.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing_extensions import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional
 
 from jax import numpy as jnp, tree as jtr
 from jaxtyping import Array

--- a/src/gwkokab/models/utils/_scaledmixture.py
+++ b/src/gwkokab/models/utils/_scaledmixture.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 
-from typing import Optional
-from typing_extensions import List
+from typing import List, Optional
 
 import jax
 from jax import lax, numpy as jnp

--- a/src/gwkokab/utils/math.py
+++ b/src/gwkokab/utils/math.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from typing_extensions import Tuple
+from typing import Tuple
 
 from jax import numpy as jnp
 from jaxtyping import Array, ArrayLike

--- a/src/gwkokab/utils/tools.py
+++ b/src/gwkokab/utils/tools.py
@@ -14,8 +14,7 @@
 
 
 import warnings
-from typing import Optional, TypeVar
-from typing_extensions import Dict
+from typing import Dict, Optional, TypeVar
 
 
 _KT = TypeVar("_KT")

--- a/tests/test_distributions_mixture.py
+++ b/tests/test_distributions_mixture.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from typing_extensions import Sequence, Tuple
+from collections.abc import Sequence
+from typing import Tuple
 
 import jax
 import jax.numpy as jnp


### PR DESCRIPTION
Remove the extra dependency of `typing_extensions` and refactor the dependent code.