### PR TITLE
chore(gh-481): add CUDA/TPU platform support in installation

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,6 +2,12 @@ PIP=pip
 UV=uv
 PIP_FLAGS=--upgrade
 TARGET?=gwkokab
+PLATFORM?=
+ifeq ($(PLATFORM),)
+	_PLATFORM=.
+else
+	_PLATFORM=.[$(PLATFORM)]
+endif
 
 .PHONY: install uninstall cache_clean help
 
@@ -10,17 +16,17 @@ UV_CHECK := $(shell command -v $(UV) 2> /dev/null)
 
 help:
 	@echo "Available targets:"
-	@echo "  install      - Install package"
-	@echo "  uninstall    - Remove package"
-	@echo "  cache_clean  - Clean pip and uv cache"
-	@echo "  docs		  - Generate documentation"
+	@echo "  install PLATFORM=... - Install package"
+	@echo "  uninstall            - Remove package"
+	@echo "  cache_clean          - Clean pip and uv cache"
+	@echo "  docs		          - Generate documentation"
 
 install: uninstall
 ifndef UV_CHECK
 	@echo "uv is not installed. Continuing without uv."
-	$(PIP) install $(PIP_FLAGS) .
+	$(PIP) install $(PIP_FLAGS) $(_PLATFORM)
 else
-	$(UV) $(PIP) install $(PIP_FLAGS) .
+	$(UV) $(PIP) install $(PIP_FLAGS) $(_PLATFORM)
 endif
 
 uninstall:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,9 @@ docs = [
     "sphinx>=2.0",
     "sphinx_design",
 ]
-test = ["astropy>=6.1.4"]
+test = []
+cuda12 = ["jax[cuda12]>=0.4.30"]
+tpu = ["jax[tpu]>=0.4.30"]
 
 [project.urls]
 Changelog = "https://github.com/gwkokab/gwkokab/blob/main/CHANGELOG.md"


### PR DESCRIPTION
## Summary

Add platform-specific installation of JAX available in `pyproject.toml`.

## Related Issues

- closes #481

## Description

We have added support to install platform-specific JAX. Before this, we had to install them separately, occasionally affecting the dependency resolution. Now we can install by specifying `gwkokab[cuda12]` or `gwkokab[tpu]` or `gwkokab` to install for cuda capable GPU, Google TPUs, or CPU respectively. For developer `make install PLATFORM=...`, where `...` will be replaced by the `cuda12` or `tpu` and for CPU based installation `make install` will work.