### PR TITLE
chore(gh-481): disable TPU support in `pyproject.toml`

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,6 +2,12 @@ PIP=pip
 UV=uv
 PIP_FLAGS=--upgrade
 TARGET?=gwkokab
+PLATFORM?=
+ifeq ($(PLATFORM),)
+	_PLATFORM=.
+else
+	_PLATFORM=.[$(PLATFORM)]
+endif
 
 .PHONY: install uninstall cache_clean help
 
@@ -10,17 +16,17 @@ UV_CHECK := $(shell command -v $(UV) 2> /dev/null)
 
 help:
 	@echo "Available targets:"
-	@echo "  install      - Install package"
-	@echo "  uninstall    - Remove package"
-	@echo "  cache_clean  - Clean pip and uv cache"
-	@echo "  docs		  - Generate documentation"
+	@echo "  install PLATFORM=... - Install package"
+	@echo "  uninstall            - Remove package"
+	@echo "  cache_clean          - Clean pip and uv cache"
+	@echo "  docs		          - Generate documentation"
 
 install: uninstall
 ifndef UV_CHECK
 	@echo "uv is not installed. Continuing without uv."
-	$(PIP) install $(PIP_FLAGS) .
+	$(PIP) install $(PIP_FLAGS) $(_PLATFORM)
 else
-	$(UV) $(PIP) install $(PIP_FLAGS) .
+	$(UV) $(PIP) install $(PIP_FLAGS) $(_PLATFORM)
 endif
 
 uninstall:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,9 @@ docs = [
     "sphinx>=2.0",
     "sphinx_design",
 ]
-test = ["astropy>=6.1.4"]
+test = []
+cuda12 = ["jax[cuda12]>=0.4.30"]
+tpu = ["jax[tpu]>=0.4.30"]
 
 [project.urls]
 Changelog = "https://github.com/gwkokab/gwkokab/blob/main/CHANGELOG.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ docs = [
 ]
 test = []
 cuda12 = ["jax[cuda12]>=0.4.30"]
-tpu = ["jax[tpu]>=0.4.30"]
+# tpu = ["jax[tpu]>=0.4.30"]
 
 [project.urls]
 Changelog = "https://github.com/gwkokab/gwkokab/blob/main/CHANGELOG.md"


### PR DESCRIPTION
## Summary

Dependency resolution failed due to `jax[tpu]`. As we most of the time use GPUs, therefore we are disabling TPU based JAX dependency installation, to debug later.

## Related Issues

- #481