### PR TITLE
refactor: enhance PPD range handling with parameter-specific range conversion

### DIFF
--- a/src/kokab/ecc_matters/common.py
+++ b/src/kokab/ecc_matters/common.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from typing import Optional
+
 from jax import numpy as jnp
 from jaxtyping import Array
 from numpyro.distributions import TruncatedNormal
@@ -31,20 +33,27 @@ def EccentricityMattersModel(
     scale: Array,
     low: Array,
     high: Array,
+    *,
+    validate_args: Optional[bool] = None,
 ) -> ScaledMixture:
     return ScaledMixture(
         log_scales=jnp.array([log_rate]),
         component_distributions=[
             JointDistribution(
                 Wysocki2019MassModel(
-                    alpha_m=alpha_m, mmin=mmin, mmax=mmax, validate_args=True
+                    alpha_m=alpha_m, mmin=mmin, mmax=mmax, validate_args=validate_args
                 ),
                 TruncatedNormal(
-                    loc=loc, scale=scale, low=low, high=high, validate_args=True
+                    loc=loc,
+                    scale=scale,
+                    low=low,
+                    high=high,
+                    validate_args=validate_args,
                 ),
             )
         ],
         support=real_vector,
+        validate_args=validate_args,
     )
 
 

--- a/src/kokab/ecc_matters/ppd.py
+++ b/src/kokab/ecc_matters/ppd.py
@@ -21,7 +21,7 @@ from gwkokab.parameters import ECCENTRICITY, PRIMARY_MASS_SOURCE, SECONDARY_MASS
 from gwkokab.utils.tools import error_if
 from kokab.ecc_matters.common import EccentricityMattersModel
 from kokab.utils import ppd, ppd_parser
-from kokab.utils.common import read_json
+from kokab.utils.common import ppd_ranges, read_json
 
 
 def make_parser() -> ArgumentParser:
@@ -48,6 +48,7 @@ def main() -> None:
         SECONDARY_MASS_SOURCE.name,
         ECCENTRICITY.name,
     ]
+    ranges = ppd_ranges(parameters, args.range)
 
     nf_samples = pd.read_csv(
         "sampler_data/nf_samples.dat", delimiter=" ", comment="#", header=None
@@ -56,7 +57,7 @@ def main() -> None:
     ppd.compute_and_save_ppd(
         EccentricityMattersModel,
         nf_samples,
-        args.range,
+        ranges,
         "rate_scaled_" + args.filename,
         parameters,
         constants,
@@ -68,7 +69,7 @@ def main() -> None:
     ppd.compute_and_save_ppd(
         EccentricityMattersModel,
         nf_samples,
-        args.range,
+        ranges,
         args.filename,
         parameters,
         constants,

--- a/src/kokab/n_pls_m_gs/ppd.py
+++ b/src/kokab/n_pls_m_gs/ppd.py
@@ -31,7 +31,7 @@ from gwkokab.parameters import (
 )
 from gwkokab.utils.tools import error_if
 from kokab.utils import ppd, ppd_parser
-from kokab.utils.common import read_json
+from kokab.utils.common import ppd_ranges, read_json
 
 
 def make_parser() -> ArgumentParser:
@@ -77,6 +77,8 @@ def main() -> None:
     if has_eccentricity:
         parameters.append(ECCENTRICITY.name)
 
+    ranges = ppd_ranges(parameters, args.range)
+
     nf_samples = pd.read_csv(
         "sampler_data/nf_samples.dat", delimiter=" ", comment="#", header=None
     ).to_numpy()
@@ -84,7 +86,7 @@ def main() -> None:
     ppd.compute_and_save_ppd(
         NPowerlawMGaussian,
         nf_samples,
-        args.range,
+        ranges,
         "rate_scaled_" + args.filename,
         parameters,
         constants,
@@ -96,7 +98,7 @@ def main() -> None:
     ppd.compute_and_save_ppd(
         NPowerlawMGaussian,
         nf_samples,
-        args.range,
+        ranges,
         args.filename,
         parameters,
         constants,

--- a/src/kokab/n_spls_m_sgs/ppd.py
+++ b/src/kokab/n_spls_m_sgs/ppd.py
@@ -36,7 +36,7 @@ from gwkokab.parameters import (
 )
 from gwkokab.utils.tools import error_if
 from kokab.utils import ppd, ppd_parser
-from kokab.utils.common import read_json
+from kokab.utils.common import ppd_ranges, read_json
 
 
 def make_parser() -> ArgumentParser:
@@ -93,6 +93,8 @@ def main() -> None:
     if has_eccentricity:
         parameters.append(ECCENTRICITY.name)
 
+    ranges = ppd_ranges(parameters, args.range)
+
     nf_samples = pd.read_csv(
         "sampler_data/nf_samples.dat", delimiter=" ", comment="#", header=None
     ).to_numpy()
@@ -100,7 +102,7 @@ def main() -> None:
     ppd.compute_and_save_ppd(
         NSmoothedPowerlawMSmoothedGaussian,
         nf_samples,
-        args.range,
+        ranges,
         "rate_scaled_" + args.filename,
         parameters,
         constants,
@@ -113,7 +115,7 @@ def main() -> None:
     ppd.compute_and_save_ppd(
         NSmoothedPowerlawMSmoothedGaussian,
         nf_samples,
-        args.range,
+        ranges,
         args.filename,
         parameters,
         constants,

--- a/src/kokab/one_powerlaw_one_peak/ppd.py
+++ b/src/kokab/one_powerlaw_one_peak/ppd.py
@@ -22,7 +22,7 @@ from gwkokab.models import SmoothedPowerlawPeakAndPowerlawRedshift
 from gwkokab.parameters import PRIMARY_MASS_SOURCE, REDSHIFT, SECONDARY_MASS_SOURCE
 from gwkokab.utils.tools import error_if
 from kokab.utils import ppd, ppd_parser
-from kokab.utils.common import read_json
+from kokab.utils.common import ppd_ranges, read_json
 
 
 def make_parser() -> ArgumentParser:
@@ -69,6 +69,8 @@ def main() -> None:
 
     parameters = [PRIMARY_MASS_SOURCE.name, SECONDARY_MASS_SOURCE.name, REDSHIFT.name]
 
+    ranges = ppd_ranges(parameters, args.range)
+
     nf_samples = pd.read_csv(
         "sampler_data/nf_samples.dat", delimiter=" ", comment="#", header=None
     ).to_numpy()
@@ -76,7 +78,7 @@ def main() -> None:
     ppd.compute_and_save_ppd(
         model,
         nf_samples,
-        args.range,
+        ranges,
         "rate_scaled_" + args.filename,
         parameters,
         constants,
@@ -89,7 +91,7 @@ def main() -> None:
     ppd.compute_and_save_ppd(
         model,
         nf_samples,
-        args.range,
+        ranges,
         args.filename,
         parameters,
         constants,

--- a/src/kokab/utils/common.py
+++ b/src/kokab/utils/common.py
@@ -16,7 +16,7 @@
 import json
 import warnings
 from collections.abc import Sequence
-from typing import Dict, List, Union
+from typing import Dict, List, Tuple, Union
 
 import jax
 import numpy as np
@@ -236,3 +236,25 @@ def get_dist(meta_dict: dict[str, Union[str, float]]) -> DistributionLike:
     """
     dist_name = meta_dict.pop("dist")
     return getattr(dist, dist_name)(**meta_dict)
+
+
+def ppd_ranges(
+    parameters: List[str], ranges: List[Tuple[str, float, float, int]]
+) -> List[Tuple[float, float, int]]:
+    """Convert the PPD ranges to the format required by the PPD function.
+
+    :param parameters: list of parameters
+    :param ranges: list of ranges
+    :return: list of ranges
+    """
+    _ranges: List[Tuple[float, float, int]] = [None] * len(parameters)
+    for name, *_range in ranges:
+        if name in parameters:
+            _ranges[parameters.index(name)] = (
+                float(_range[0]),
+                float(_range[1]),
+                int(_range[2]),
+            )
+        else:
+            raise ValueError(f"Parameter {name} not found in {parameters}.")
+    return _ranges

--- a/src/kokab/utils/ppd_parser.py
+++ b/src/kokab/utils/ppd_parser.py
@@ -51,11 +51,11 @@ def get_parser(parser: ArgumentParser) -> ArgumentParser:
     )
     ppd_group.add_argument(
         "--range",
-        help="Range of the PPD for each parameter. The format is 'min max step'. "
+        help="Range of the PPD for each parameter. The format is 'name min max step'. "
         "Repeat for each parameter.",
-        nargs=3,
+        nargs=4,
         action="append",
-        type=float,
+        type=str,
         required=True,
     )
     ppd_group.add_argument(


### PR DESCRIPTION
## Summary

With this update, we can pass ranges in the PPD generation script by the name of parameters without any order like `--range name min max step`.