### PR TITLE
refactor(gh-460): optimize PPD computation with itertools product and simplified mesh generation

### DIFF
--- a/src/kokab/utils/ppd.py
+++ b/src/kokab/utils/ppd.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+from itertools import product
 from multiprocessing import pool
 from typing import Dict, List, Tuple, Union
 
@@ -170,13 +171,8 @@ def compute_and_save_ppd(
     nf_samples_mapping: Dict[str, int],
     n_threads: int = 1,
 ) -> None:
-    xx = [np.linspace(a, b, int(n)) for a, b, n in domains]
-    mesh = np.meshgrid(*xx, indexing="ij")
-    del xx
-    xx_mesh = np.stack(mesh, axis=-1)
-    del mesh
-    shape = xx_mesh.shape
-    xx_mesh = xx_mesh.reshape(-1, shape[-1])
+    xx_mesh = [np.linspace(a, b, int(n)) for a, b, n in domains]
+    shape = tuple(d[2] for d in domains)
 
     def _compute_probs(params: np.ndarray) -> np.ndarray:
         _model = model(
@@ -184,7 +180,11 @@ def compute_and_save_ppd(
             **{k: params[v] for k, v in nf_samples_mapping.items()},
             validate_args=True,
         )
-        prob_value = np.exp(_model.log_prob(xx_mesh))
+        prob_value = np.exp(
+            np.asarray(
+                [_model.log_prob(np.asarray(list(k))) for k in product(*xx_mesh)]
+            )
+        )
         del params
         del _model
         return prob_value

--- a/src/kokab/utils/ppd.py
+++ b/src/kokab/utils/ppd.py
@@ -180,10 +180,8 @@ def compute_and_save_ppd(
             **{k: params[v] for k, v in nf_samples_mapping.items()},
             validate_args=True,
         )
-        prob_value = np.exp(
-            np.asarray(
-                [_model.log_prob(np.asarray(list(k))) for k in product(*xx_mesh)]
-            )
+        prob_value = np.asarray(
+            [np.exp(_model.log_prob(np.asarray(k))) for k in product(*xx_mesh)]
         )
         del params
         del _model


### PR DESCRIPTION
## Summary

We were facing memory exhaustion errors,

```bash
numpy._core._exceptions._ArrayMemoryError: Unable to allocate 2.33 TiB for an array with shape (200, 200, 200, 200, 200) and data type float64
```

We were making and storing a mesh grid, which is manageable for 1-3 dimensions, but after that, the memory space required to store all this mesh grid goes out of bounds. Therefore, we are not creating meshgrids but iterating over them, which is a little inefficient, but it saves us from the above-mentioned memory errors.

## Related Issues

- #460