### PR TITLE
revert(gh-478): ppd generation previous method using `jax.lax.map` and `jax.vmap`

### DIFF
--- a/src/kokab/ecc_matters/ppd.py
+++ b/src/kokab/ecc_matters/ppd.py
@@ -62,6 +62,7 @@ def main() -> None:
         parameters,
         constants,
         nf_samples_mapping,
+        args.batch_size,
     )
 
     nf_samples, constants = ppd.wipe_log_rate(nf_samples, nf_samples_mapping, constants)
@@ -74,4 +75,5 @@ def main() -> None:
         parameters,
         constants,
         nf_samples_mapping,
+        args.batch_size,
     )

--- a/src/kokab/n_pls_m_gs/ppd.py
+++ b/src/kokab/n_pls_m_gs/ppd.py
@@ -91,6 +91,7 @@ def main() -> None:
         parameters,
         constants,
         nf_samples_mapping,
+        args.batch_size,
     )
 
     nf_samples, constants = ppd.wipe_log_rate(nf_samples, nf_samples_mapping, constants)
@@ -103,4 +104,5 @@ def main() -> None:
         parameters,
         constants,
         nf_samples_mapping,
+        args.batch_size,
     )

--- a/src/kokab/n_spls_m_sgs/ppd.py
+++ b/src/kokab/n_spls_m_sgs/ppd.py
@@ -107,7 +107,7 @@ def main() -> None:
         parameters,
         constants,
         nf_samples_mapping,
-        args.n_threads,
+        args.batch_size,
     )
 
     nf_samples, constants = ppd.wipe_log_rate(nf_samples, nf_samples_mapping, constants)
@@ -120,5 +120,5 @@ def main() -> None:
         parameters,
         constants,
         nf_samples_mapping,
-        args.n_threads,
+        args.batch_size,
     )

--- a/src/kokab/one_powerlaw_one_peak/ppd.py
+++ b/src/kokab/one_powerlaw_one_peak/ppd.py
@@ -83,7 +83,7 @@ def main() -> None:
         parameters,
         constants,
         nf_samples_mapping,
-        args.n_threads,
+        args.batch_size,
     )
 
     nf_samples, constants = ppd.wipe_log_rate(nf_samples, nf_samples_mapping, constants)
@@ -96,5 +96,5 @@ def main() -> None:
         parameters,
         constants,
         nf_samples_mapping,
-        args.n_threads,
+        args.batch_size,
     )

--- a/src/kokab/utils/ppd_parser.py
+++ b/src/kokab/utils/ppd_parser.py
@@ -65,10 +65,10 @@ def get_parser(parser: ArgumentParser) -> ArgumentParser:
         required=True,
     )
     ppd_group.add_argument(
-        "--n-threads",
-        help="Number of threads to use for the computation.",
+        "--batch-size",
+        help="Batch size for the computation of log prob per sample.",
         type=int,
-        default=1,
+        default=1000,
     )
 
     return parser


### PR DESCRIPTION
## Summary

We have reverted the use of multithreading for ppd generation and returned to JAX-based methods, because they are fast.

## Related To

- #461
- #478

## Description

Multithreading took enormous time, even days to compute simple and small grid size PPDs. It was better for us to use JAX-based method with little tweaks in memory consumptions.