### PR TITLE
feat: add font family customization option to plotting scripts

### DIFF
--- a/src/cli_gwkokab/batch_scatter2d.py
+++ b/src/cli_gwkokab/batch_scatter2d.py
@@ -106,6 +106,12 @@ def make_parser() -> argparse.ArgumentParser:
         help="use LaTeX for rendering text",
         action="store_true",
     )
+    parser.add_argument(
+        "--font-family",
+        help="font family to use",
+        type=str,
+        default=None,
+    )
 
     return parser
 
@@ -116,6 +122,8 @@ def main() -> None:
     args = parser.parse_args()
 
     plt.rcParams.update({"text.usetex": args.use_latex})
+    if args.font_family is not None:
+        plt.rcParams.update({"font.family": args.font_family})
 
     file_list = glob.glob(args.data_regex)
 

--- a/src/cli_gwkokab/batch_scatter3d.py
+++ b/src/cli_gwkokab/batch_scatter3d.py
@@ -141,6 +141,12 @@ def make_parser() -> argparse.ArgumentParser:
         help="use LaTeX for rendering text",
         action="store_true",
     )
+    parser.add_argument(
+        "--font-family",
+        help="font family to use",
+        type=str,
+        default=None,
+    )
 
     return parser
 
@@ -153,6 +159,8 @@ def main() -> None:
     file_list = glob.glob(args.data_regex)
 
     plt.rcParams.update({"text.usetex": args.use_latex})
+    if args.font_family is not None:
+        plt.rcParams.update({"font.family": args.font_family})
 
     fig = plt.figure()
     ax = fig.add_subplot(111, projection="3d")

--- a/src/cli_gwkokab/chain_plot.py
+++ b/src/cli_gwkokab/chain_plot.py
@@ -100,6 +100,12 @@ def make_parser() -> argparse.ArgumentParser:
         help="use LaTeX for rendering text",
         action="store_true",
     )
+    parser.add_argument(
+        "--font-family",
+        help="font family to use",
+        type=str,
+        default=None,
+    )
 
     return parser
 
@@ -109,6 +115,8 @@ def main() -> None:
     args = parser.parse_args()
 
     plt.rcParams.update({"text.usetex": args.use_latex})
+    if args.font_family is not None:
+        plt.rcParams.update({"font.family": args.font_family})
 
     files = glob.glob(args.data_regex)
     n_dim = args.dimension

--- a/src/cli_gwkokab/corner_plot.py
+++ b/src/cli_gwkokab/corner_plot.py
@@ -120,6 +120,12 @@ def make_parser() -> argparse.ArgumentParser:
         help="use LaTeX for rendering text",
         action="store_true",
     )
+    parser.add_argument(
+        "--font-family",
+        help="font family to use",
+        type=str,
+        default=None,
+    )
 
     return parser
 
@@ -130,6 +136,9 @@ def main() -> None:
     args = parser.parse_args()
 
     plt.rcParams.update({"text.usetex": args.use_latex})
+    if args.font_family is not None:
+        plt.rcParams.update({"font.family": args.font_family})
+
     data = pd.read_csv(args.data.name, delimiter=" ", skiprows=1).to_numpy()
     figure = corner.corner(
         data,

--- a/src/cli_gwkokab/ess_plot.py
+++ b/src/cli_gwkokab/ess_plot.py
@@ -68,6 +68,12 @@ def make_parser() -> argparse.ArgumentParser:
         help="use LaTeX for rendering text",
         action="store_true",
     )
+    parser.add_argument(
+        "--font-family",
+        help="font family to use",
+        type=str,
+        default=None,
+    )
 
     return parser
 
@@ -78,6 +84,8 @@ def main() -> None:
     args = parser.parse_args()
 
     plt.rcParams.update({"text.usetex": args.use_latex})
+    if args.font_family is not None:
+        plt.rcParams.update({"font.family": args.font_family})
 
     train_paths = glob.glob(args.train_chain_regex)
     prod_paths = glob.glob(args.production_chain_regex)

--- a/src/cli_gwkokab/joint_plot.py
+++ b/src/cli_gwkokab/joint_plot.py
@@ -99,6 +99,12 @@ def make_parser() -> argparse.ArgumentParser:
         help="use LaTeX for rendering text",
         action="store_true",
     )
+    parser.add_argument(
+        "--font-family",
+        help="font family to use",
+        type=str,
+        default=None,
+    )
 
     return parser
 
@@ -109,6 +115,8 @@ def main() -> None:
     args = parser.parse_args()
 
     plt.rcParams.update({"text.usetex": args.use_latex})
+    if args.font_family is not None:
+        plt.rcParams.update({"font.family": args.font_family})
 
     data = pd.read_csv(args.data.name, delimiter=" ")
 

--- a/src/cli_gwkokab/ppd_plot.py
+++ b/src/cli_gwkokab/ppd_plot.py
@@ -103,6 +103,12 @@ def make_parser() -> argparse.ArgumentParser:
         action="store_true",
     )
     pretty_group.add_argument(
+        "--font-family",
+        help="font family to use",
+        type=str,
+        default=None,
+    )
+    pretty_group.add_argument(
         "--median-color",
         help="color of the median line",
         type=str,
@@ -193,6 +199,8 @@ def main() -> None:
     args = parser.parse_args()
 
     plt.rcParams.update({"text.usetex": args.use_latex})
+    if args.font_family is not None:
+        plt.rcParams.update({"font.family": args.font_family})
 
     prefix = "" if args.prefix is None else args.prefix
 

--- a/src/cli_gwkokab/r_hat_plot.py
+++ b/src/cli_gwkokab/r_hat_plot.py
@@ -81,6 +81,12 @@ def make_parser() -> argparse.ArgumentParser:
         help="use LaTeX for rendering text",
         action="store_true",
     )
+    parser.add_argument(
+        "--font-family",
+        help="font family to use",
+        type=str,
+        default=None,
+    )
 
     return parser
 
@@ -91,6 +97,8 @@ def main() -> None:
     args = parser.parse_args()
 
     plt.rcParams.update({"text.usetex": args.use_latex})
+    if args.font_family is not None:
+        plt.rcParams.update({"font.family": args.font_family})
 
     chains_filenames = glob(args.chains_regex)
     chains = np.array([np.loadtxt(filename) for filename in chains_filenames])

--- a/src/cli_gwkokab/scatter2d.py
+++ b/src/cli_gwkokab/scatter2d.py
@@ -120,6 +120,12 @@ def make_parser() -> argparse.ArgumentParser:
         help="use LaTeX for rendering text",
         action="store_true",
     )
+    parser.add_argument(
+        "--font-family",
+        help="font family to use",
+        type=str,
+        default=None,
+    )
 
     return parser
 
@@ -130,6 +136,8 @@ def main() -> None:
     args = parser.parse_args()
 
     plt.rcParams.update({"text.usetex": args.use_latex})
+    if args.font_family is not None:
+        plt.rcParams.update({"font.family": args.font_family})
 
     if args.color:
         color = np.loadtxt(args.color)

--- a/src/cli_gwkokab/scatter3d.py
+++ b/src/cli_gwkokab/scatter3d.py
@@ -126,6 +126,12 @@ def make_parser() -> argparse.ArgumentParser:
         help="use LaTeX for rendering text",
         action="store_true",
     )
+    parser.add_argument(
+        "--font-family",
+        help="font family to use",
+        type=str,
+        default=None,
+    )
 
     return parser
 
@@ -136,6 +142,8 @@ def main() -> None:
     args = parser.parse_args()
 
     plt.rcParams.update({"text.usetex": args.use_latex})
+    if args.font_family is not None:
+        plt.rcParams.update({"font.family": args.font_family})
 
     data = pd.read_csv(args.data.name, delimiter=" ")
     x = data[args.x_value_column_name].to_numpy()


### PR DESCRIPTION
## Summary

Added a new command-line argument `--font-family` to various plotting scripts, allowing users to specify the font family for rendering text. This enhancement improves customization options for visual outputs across multiple plot types.