### PR TITLE
feat: change in neural VT architecture to `equinox.nn.MLP`

### DIFF
--- a/src/gwkokab/vts/__init__.py
+++ b/src/gwkokab/vts/__init__.py
@@ -1,16 +1,5 @@
-#  Copyright 2023 The GWKokab Authors
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Copyright 2023 The GWKokab Authors
+# SPDX-License-Identifier: Apache-2.0
 
 
 #

--- a/src/gwkokab/vts/_abc.py
+++ b/src/gwkokab/vts/_abc.py
@@ -1,16 +1,6 @@
 # Copyright 2023 The GWKokab Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+
 
 from abc import abstractmethod
 from collections.abc import Callable, Sequence

--- a/src/gwkokab/vts/_injvt.py
+++ b/src/gwkokab/vts/_injvt.py
@@ -1,16 +1,5 @@
-#  Copyright 2023 The GWKokab Authors
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Copyright 2023 The GWKokab Authors
+# SPDX-License-Identifier: Apache-2.0
 
 
 from collections.abc import Sequence

--- a/src/gwkokab/vts/_neuralvt.py
+++ b/src/gwkokab/vts/_neuralvt.py
@@ -1,16 +1,5 @@
-#  Copyright 2023 The GWKokab Authors
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Copyright 2023 The GWKokab Authors
+# SPDX-License-Identifier: Apache-2.0
 
 
 from collections.abc import Callable, Sequence
@@ -26,7 +15,7 @@ from ._utils import load_model
 
 
 class NeuralNetVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
-    neural_vt_model: eqx.nn.Sequential = eqx.field(init=False)
+    neural_vt_model: eqx.nn.MLP = eqx.field(init=False)
     """The neural volume-time sensitivity model."""
 
     def __init__(

--- a/src/gwkokab/vts/_popmodelvt.py
+++ b/src/gwkokab/vts/_popmodelvt.py
@@ -1,16 +1,6 @@
-#  Copyright 2023 The GWKokab Authors
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Copyright 2023 The GWKokab Authors
+# SPDX-License-Identifier: Apache-2.0
+
 
 from collections.abc import Callable, Sequence
 from typing import Literal, Optional, overload, Tuple

--- a/src/gwkokab/vts/_train.py
+++ b/src/gwkokab/vts/_train.py
@@ -1,19 +1,8 @@
-#  Copyright 2023 The GWKokab Authors
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Copyright 2023 The GWKokab Authors
+# SPDX-License-Identifier: Apache-2.0
 
 
-from typing import Optional
+from typing import Callable, Optional
 
 import equinox as eqx
 import jax
@@ -76,7 +65,8 @@ def train_regressor(
     *,
     input_keys: list[str],
     output_keys: list[str],
-    hidden_layers: list[int],
+    width_size: int,
+    depth: int,
     batch_size: int,
     data_path: str,
     checkpoint_path: Optional[str] = None,
@@ -90,8 +80,10 @@ def train_regressor(
         list of input keys
     output_keys : list[str]
         list of output keys
-    hidden_layers : list[int]
-        list of hidden layers
+    width_size : list[int]
+        width size of the model
+    depth : int
+        depth of the model
     batch_size : int
         batch size for training
     data_path : str
@@ -119,16 +111,16 @@ def train_regressor(
 
     @eqx.filter_jit
     def make_step(
-        model: eqx.nn.Sequential,
+        model: eqx.nn.MLP,
         x: Array,
         y: Array,
         opt_state: optax.OptState,
-    ) -> tuple[eqx.nn.Sequential, optax.OptState, Array]:
+    ) -> tuple[eqx.nn.MLP, optax.OptState, Array]:
         """Make a step in the optimization process.
 
         Parameters
         ----------
-        model : eqx.nn.Sequential
+        model : eqx.nn.MLP
             Model to approximate the log of the VT function
         x : Array
             input data
@@ -139,7 +131,7 @@ def train_regressor(
 
         Returns
         -------
-        tuple[eqx.nn.Sequential, optax.OptState, Array]
+        tuple[eqx.nn.MLP, optax.OptState, Array]
             optimizer state
         """
         loss, grads = mse_loss_fn(model, x, y)
@@ -148,16 +140,16 @@ def train_regressor(
         return model, opt_state, loss
 
     def train_step(
-        model: eqx.nn.Sequential,
+        model: eqx.nn.MLP,
         x: Array,
         y: Array,
         opt_state: optax.OptState,
-    ) -> tuple[eqx.nn.Sequential, optax.OptState, Array]:
+    ) -> tuple[eqx.nn.MLP, optax.OptState, Array]:
         """Train the model for one epoch.
 
         Parameters
         ----------
-        model : eqx.nn.Sequential
+        model : eqx.nn.MLP
             Model to approximate the log of the VT function
         x : Array
             input data
@@ -168,7 +160,7 @@ def train_regressor(
 
         Returns
         -------
-        tuple[eqx.nn.Sequential, optax.OptState, Array]
+        tuple[eqx.nn.MLP, optax.OptState, Array]
             optimizer state
         """
         model, opt_state, loss = make_step(model, x, y, opt_state)
@@ -176,8 +168,8 @@ def train_regressor(
 
     df = read_data(data_path)
 
-    data_X = jax.device_put(df[input_keys].to_numpy())
-    data_Y = jax.device_put(df[output_keys].to_numpy())
+    data_X = jax.device_put(df[input_keys].to_numpy(), may_alias=True)
+    data_Y = jax.device_put(df[output_keys].to_numpy(), may_alias=True)
 
     log_data_Y = jnp.log(data_Y)
     log_data_Y = jnp.where(
@@ -196,7 +188,8 @@ def train_regressor(
     table.add_column("Value", justify="left")
     table.add_row("Input Keys", ", ".join(input_keys))
     table.add_row("Output Keys", ", ".join(output_keys))
-    table.add_row("Hidden Layers", ", ".join(map(str, hidden_layers)))
+    table.add_row("Width Size", str(width_size))
+    table.add_row("Depth", str(depth))
     table.add_row("Data Path", data_path)
     table.add_row("Checkpoint Path", checkpoint_path)
     table.add_row("Train Size", str(len(train_X)))
@@ -213,14 +206,19 @@ def train_regressor(
         key=jrd.PRNGKey(np.random.randint(0, 2**32 - 1)),
         input_layer=len(input_keys),
         output_layer=len(output_keys),
-        hidden_layers=hidden_layers,
+        width_size=width_size,
+        depth=depth,
     )
+
+    model: Callable = eqx.filter_checkpoint(model)  # type: ignore
 
     opt_state = optimizer.init(eqx.filter(model, eqx.is_inexact_array))
 
     loss_vals = []
     val_loss_vals = []
 
+    total = int(len(train_X) // batch_size)
+    epoch_loss = jnp.zeros(())
     with Progress(
         SpinnerColumn(),
         TextColumn("Epoch {task.fields[epoch]}"),
@@ -230,14 +228,12 @@ def train_regressor(
         TextColumn("[progress.description]{task.description}"),
         refresh_per_second=5,
     ) as progress:
-        total = int(len(train_X) // batch_size)
         for epoch in range(epochs):
             task_id = progress.add_task(
                 "",
                 total=total,
                 epoch=epoch + 1,
             )
-            epoch_loss = jnp.zeros(())
             for i in range(0, len(train_X), batch_size):
                 x = train_X[i : i + batch_size]
                 y = train_Y[i : i + batch_size]
@@ -258,11 +254,12 @@ def train_regressor(
             progress.update(
                 task_id,
                 completed=total,
+                refresh=True,
                 description=f"loss: {loss:.4f} - val loss: {val_loss:.4f}",
             )
 
     if checkpoint_path is not None:
-        save_model(filename=checkpoint_path, model=model, names=input_keys)
+        save_model(filename=checkpoint_path, model=model, names=input_keys)  # type: ignore
         plt.plot(loss_vals, label="loss")
         plt.plot(val_loss_vals, label="val loss")
         plt.yscale("log")

--- a/src/gwkokab/vts/_train.py
+++ b/src/gwkokab/vts/_train.py
@@ -80,7 +80,7 @@ def train_regressor(
         list of input keys
     output_keys : list[str]
         list of output keys
-    width_size : list[int]
+    width_size : int
         width size of the model
     depth : int
         depth of the model

--- a/src/gwkokab/vts/_utils.py
+++ b/src/gwkokab/vts/_utils.py
@@ -44,7 +44,7 @@ def mse_loss_fn(
     batch_size : Optional[int], optional
         batch size for training, by default 256. This is used to avoid OOM errors when
         training large datasets. If None, the entire dataset will be trained
-        MLPly. This is not recommended for large datasets.
+        sequentially. This is not recommended for large datasets.
 
     Returns
     -------
@@ -68,7 +68,7 @@ def predict(model: PyTree, x: Array, batch_size: Optional[int] = 256) -> Array:
     batch_size : Optional[int], optional
         batch size for prediction, by default 256. This is used to avoid OOM errors when
         predicting large datasets. If None, the entire dataset will be predicted
-        MLPly. This is not recommended for large datasets.
+        sequentially. This is not recommended for large datasets.
 
     Returns
     -------
@@ -102,8 +102,8 @@ def make_model(
     key: PRNGKeyArray,
     input_layer: int,
     output_layer: int,
-    width_size: int = 0,
-    depth: int = 0,
+    width_size: int,
+    depth: int,
 ) -> eqx.nn.MLP:
     """Make a neural network model to approximate the log of the VT function.
 
@@ -115,8 +115,10 @@ def make_model(
         input layer of the model
     output_layer : int
         output layer of the model
-    hidden_layers : Optional[List[int]], optional
-        hidden layers of the model, by default None
+    width_size : int
+        width size of the model
+    depth : int
+        depth of the model
 
     Returns
     -------

--- a/src/gwkokab/vts/_utils.py
+++ b/src/gwkokab/vts/_utils.py
@@ -1,21 +1,10 @@
-#  Copyright 2023 The GWKokab Authors
-#
-#  Licensed under the Apache License, Version 2.0 (the "License");
-#  you may not use this file except in compliance with the License.
-#  You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-#  Unless required by applicable law or agreed to in writing, software
-#  distributed under the License is distributed on an "AS IS" BASIS,
-#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#  See the License for the specific language governing permissions and
-#  limitations under the License.
+# Copyright 2023 The GWKokab Authors
+# SPDX-License-Identifier: Apache-2.0
 
 
 import warnings
 from collections.abc import Sequence
-from typing import Any, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import equinox as eqx
 import h5py
@@ -38,7 +27,10 @@ __all__ = [
 
 
 @eqx.filter_value_and_grad
-def mse_loss_fn(model: PyTree, x: Array, y: Array) -> Array:
+@eqx.filter_jit
+def mse_loss_fn(
+    model: PyTree, x: Array, y: Array, batch_size: Optional[int] = 256
+) -> Array:
     """Mean squared error loss function.
 
     Parameters
@@ -49,18 +41,22 @@ def mse_loss_fn(model: PyTree, x: Array, y: Array) -> Array:
         input data
     y : Array
         output data
+    batch_size : Optional[int], optional
+        batch size for training, by default 256. This is used to avoid OOM errors when
+        training large datasets. If None, the entire dataset will be trained
+        MLPly. This is not recommended for large datasets.
 
     Returns
     -------
     Array
         mean squared error
     """
-    y_pred = jax.vmap(model)(x)
+    y_pred = jax.lax.map(model, x, batch_size=batch_size)
     return jnp.mean(jnp.square(y - y_pred))  # mean squared error
 
 
 @eqx.filter_jit
-def predict(model: PyTree, x: Array) -> Array:
+def predict(model: PyTree, x: Array, batch_size: Optional[int] = 256) -> Array:
     """Predict the output of the model given the input data.
 
     Parameters
@@ -69,13 +65,17 @@ def predict(model: PyTree, x: Array) -> Array:
         Model to approximate the log of the VT function
     x : Array
         input data
+    batch_size : Optional[int], optional
+        batch size for prediction, by default 256. This is used to avoid OOM errors when
+        predicting large datasets. If None, the entire dataset will be predicted
+        MLPly. This is not recommended for large datasets.
 
     Returns
     -------
     Array
         predicted output
     """
-    return jax.vmap(model)(x)
+    return jax.lax.map(model, x, batch_size=batch_size)
 
 
 def read_data(data_path: str) -> pd.DataFrame:
@@ -102,8 +102,9 @@ def make_model(
     key: PRNGKeyArray,
     input_layer: int,
     output_layer: int,
-    hidden_layers: Optional[List[int]] = None,
-) -> eqx.nn.Sequential:
+    width_size: int = 0,
+    depth: int = 0,
+) -> eqx.nn.MLP:
     """Make a neural network model to approximate the log of the VT function.
 
     Parameters
@@ -119,56 +120,26 @@ def make_model(
 
     Returns
     -------
-    eqx.nn.Sequential
+    eqx.nn.MLP
         neural network model
     """
     assert is_prng_key(key)
-    if hidden_layers is None:
-        keys = jrd.split(key, 2)
-        layers: List[eqx.nn.Linear | eqx.nn.Lambda] = [
-            eqx.nn.Linear(
-                in_features=input_layer,
-                out_features=output_layer,
-                key=keys[0],
-            )
-        ]
-        model = eqx.nn.Sequential(layers)
-        return model
 
-    keys = jrd.split(key, 2 + len(hidden_layers))
-
-    layers = [
-        eqx.nn.Linear(
-            in_features=input_layer,
-            out_features=hidden_layers[0],
-            key=keys[0],
-        ),
-        eqx.nn.Lambda(jnn.relu),
-    ]
-    for i in range(len(hidden_layers) - 1):
-        layers.append(
-            eqx.nn.Linear(
-                in_features=hidden_layers[i],
-                out_features=hidden_layers[i + 1],
-                key=keys[i + 1],
-            ),
-        )
-        layers.append(eqx.nn.Lambda(jnn.relu))
-    layers.append(
-        eqx.nn.Linear(
-            in_features=hidden_layers[-1], out_features=output_layer, key=keys[-1]
-        )
+    model = eqx.nn.MLP(
+        in_size=input_layer,
+        out_size=output_layer,
+        width_size=width_size,
+        depth=depth,
+        activation=jnn.relu,
+        key=key,
     )
-
-    model = eqx.nn.Sequential(layers)
-
     return model
 
 
 def save_model(
     *,
     filename: str,
-    model: eqx.nn.Sequential,
+    model: eqx._ad._CheckpointWrapper,
     names: Optional[Sequence[str]] = None,
 ) -> None:
     """Save the model to the given file.
@@ -177,7 +148,7 @@ def save_model(
     ----------
     filename : str
         Name of the file to save the model
-    model : eqx.nn.Sequential
+    model : eqx.nn.MLP
         Model to approximate the log of the VT function
     names : Optional[Sequence[str]], optional
         names of the parameters, by default None
@@ -189,20 +160,22 @@ def save_model(
             warnings.warn(
                 f"Neural VT path does not end with .hdf5: {old_filename}. Saving to {filename} instead."
             )
-    num_layers = len(model.layers)
+    model: eqx.nn.MLP = model._fun  # type: ignore
     with h5py.File(filename, "w") as f:
         if names is not None:
             f.create_dataset("names", data=np.array(names, dtype="S"))
-        for i in range(0, num_layers, 2):
-            layer_number = i >> 1
-            layer_i = f.create_group(f"layer_{layer_number}")
-            layer_i.create_dataset(
-                f"weight_{layer_number}", data=model.layers[i].weight
-            )
-            layer_i.create_dataset(f"bias_{layer_number}", data=model.layers[i].bias)
+        f.create_dataset("in_size", data=model.in_size)  # type: ignore
+        f.create_dataset("out_size", data=model.out_size)  # type: ignore
+        f.create_dataset("width_size", data=model.width_size)  # type: ignore
+        f.create_dataset("depth", data=model.depth)  # type: ignore
+        num_layers = len(model.layers)  # type: ignore
+        for i in range(num_layers):
+            layer_i = f.create_group(f"layer_{i}")
+            layer_i.create_dataset(f"weight_{i}", data=model.layers[i].weight)  # type: ignore
+            layer_i.create_dataset(f"bias_{i}", data=model.layers[i].bias)  # type: ignore
 
 
-def load_model(filename) -> Tuple[List[str], eqx.nn.Sequential]:
+def load_model(filename) -> Tuple[List[str], eqx.nn.MLP]:
     """Load the model from the given file.
 
     Parameters
@@ -212,29 +185,31 @@ def load_model(filename) -> Tuple[List[str], eqx.nn.Sequential]:
 
     Returns
     -------
-    Tuple[List[str], eqx.nn.Sequential]
+    Tuple[List[str], eqx.nn.MLP]
         names of the parameters and the model
     """
-    layers: List[Any] = []
     with h5py.File(filename, "r") as f:
         names = f["names"][:]
         names = names.astype(str).tolist()
+        in_size = int(f["in_size"][()])
+        out_size = int(f["out_size"][()])
+        width_size = int(f["width_size"][()])
+        depth = int(f["depth"][()])
+        new_model = eqx.nn.MLP(
+            in_size=in_size,
+            out_size=out_size,
+            width_size=width_size,
+            depth=depth,
+            activation=jnn.relu,
+            key=jrd.PRNGKey(0),
+        )
         i = 0
         while f.get(f"layer_{i}"):
             layer_i = f[f"layer_{i}"]
             weight_i = jax.device_put(np.asarray(layer_i[f"weight_{i}"][:]))
             bias_i = jax.device_put(np.asarray(layer_i[f"bias_{i}"][:]))
-            nn = eqx.nn.Linear(
-                in_features=weight_i.shape[1],
-                out_features=weight_i.shape[0],
-                key=jrd.PRNGKey(0),
-            )
-            nn = eqx.tree_at(lambda l: l.weight, nn, weight_i)
-            nn = eqx.tree_at(lambda l: l.bias, nn, bias_i)
-            layers.append(nn)
-            layers.append(eqx.nn.Lambda(jnn.relu))
+            new_model = eqx.tree_at(lambda m: m.layers[i].weight, new_model, weight_i)
+            new_model = eqx.tree_at(lambda m: m.layers[i].bias, new_model, bias_i)
             i += 1
-    layers.pop(-1)  # remove the last relu layer
-    new_model = eqx.nn.Sequential(layers)
 
     return names, new_model

--- a/src/gwkokab/vts/_vt.py
+++ b/src/gwkokab/vts/_vt.py
@@ -1,16 +1,6 @@
 # Copyright 2023 The GWKokab Authors
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#    http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# SPDX-License-Identifier: Apache-2.0
+
 
 import sys
 from typing import List


### PR DESCRIPTION
## Summary

- We have changed neural VT architecture to `equinox.nn.MLP` from `equinox.nn.Sequential`.
- Introduced batching the loss evaluation and prediction.
- Changed the missed license headers in #499 to SPDX short forms.

## Related To

- #133
- #499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified and standardized licensing information across the codebase by replacing extended notices with concise SPDX identifiers.

- **Refactor**
  - Updated the model architecture interfaces used in training, prediction, and model creation, switching from a sequential design to a multi-layer perceptron.
  - Renamed and restructured key training parameters (e.g., replacing a list of hidden layers with dedicated width and depth settings) and enhanced batch processing defaults for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->