### PR TITLE
refactor(gh-516): change required arguments to default values in parser functions

### DIFF
--- a/src/kokab/utils/genie_parser.py
+++ b/src/kokab/utils/genie_parser.py
@@ -39,7 +39,7 @@ def get_parser(parser: ArgumentParser) -> ArgumentParser:
         "--vt-json",
         help="Path to the JSON file containing the VT options.",
         type=str,
-        required=True,
+        default="vt.json",
     )
 
     pmean_group = parser.add_argument_group("Poisson Mean Options")
@@ -48,7 +48,7 @@ def get_parser(parser: ArgumentParser) -> ArgumentParser:
         "--pmean-json",
         help="Path to the JSON file containing the Poisson mean options.",
         type=str,
-        required=True,
+        default="pmean.json",
     )
 
     return parser

--- a/src/kokab/utils/ppd_parser.py
+++ b/src/kokab/utils/ppd_parser.py
@@ -36,13 +36,13 @@ def get_parser(parser: ArgumentParser) -> ArgumentParser:
         "--constants",
         help="Path to the JSON file containing the constant parameters.",
         type=str,
-        required=True,
+        default="constants.json",
     )
     ppd_group.add_argument(
         "--nf-samples-mapping",
         help="Path to the JSON file containing the mapping of the number of samples.",
         type=str,
-        required=True,
+        default="nf_samples_mapping.json",
     )
     ppd_group.add_argument(
         "--range",

--- a/src/kokab/utils/sage_parser.py
+++ b/src/kokab/utils/sage_parser.py
@@ -45,7 +45,7 @@ def get_parser(parser: ArgumentParser) -> ArgumentParser:
         "--vt-json",
         help="Path to the JSON file containing the VT options.",
         type=str,
-        required=True,
+        default="vt.json",
     )
 
     pmean_group = parser.add_argument_group("Poisson Mean Options")
@@ -54,7 +54,7 @@ def get_parser(parser: ArgumentParser) -> ArgumentParser:
         "--pmean-json",
         help="Path to the JSON file containing the Poisson mean options.",
         type=str,
-        required=True,
+        default="pmean.json",
     )
 
     flowMC_group = parser.add_argument_group("flowMC Options")
@@ -64,6 +64,8 @@ def get_parser(parser: ArgumentParser) -> ArgumentParser:
         help="Path to a JSON file containing the flowMC options. It should contains"
         "keys: local_sampler_kwargs, nf_model_kwargs, sampler_kwargs, data_dump_kwargs,"
         " and their respective values.",
+        default="flowMC.json",
+        type=str,
     )
 
     adam_group = parser.add_argument_group("Adam Options")
@@ -83,7 +85,7 @@ def get_parser(parser: ArgumentParser) -> ArgumentParser:
         "--prior-json",
         type=str,
         help="Path to a JSON file containing the prior distributions.",
-        required=True,
+        default="prior.json",
     )
 
     debug_group = parser.add_argument_group("Debug Options")


### PR DESCRIPTION
## Summary

We have set an unofficial nomenclature for files. We could set it as the default and make those arguments official, reducing the arguments passed in the CLI.

## Related To

- closes #516 