### PR TITLE
fix(gh-553): max `ndims` of a costraint is `prototype.ndim`

### DIFF
--- a/src/gwkokab/models/constraints.py
+++ b/src/gwkokab/models/constraints.py
@@ -304,7 +304,7 @@ class _AllConstraint(Constraint):
                     axis=self.event_dim,
                 )
             feasible_values.append(constraint.feasible_like(prototype_slice))
-        max_ndim = max([feasible_value.ndim for feasible_value in feasible_values])
+        max_ndim = prototype.ndim
         feasible_values = [
             jnp.expand_dims(
                 feasible_value, axis=tuple(range(feasible_value.ndim, max_ndim))


### PR DESCRIPTION
## Summary

It arose because all distributions were single variates, and the `jnp.concatenate` concatenated them one after another instead of expanding the dims and concatenating them. This PR fixes this issue.

## Related To

- Fixes #553 