### PR TITLE
fix(closes gh-557): add validation function to ensure tilt scales are positive

### DIFF
--- a/src/gwkokab/inference/poissonlikelihood.py
+++ b/src/gwkokab/inference/poissonlikelihood.py
@@ -183,7 +183,7 @@ def poisson_likelihood(
             name: jax.lax.dynamic_index_in_dim(x, i, keepdims=False)
             for name, i in variables_index.items()
         }
-        predicate = priors.support(x)
+        predicate = priors.support.check(x)
         for where_fn in where_fns:  # type: ignore
             predicate = jnp.logical_and(
                 predicate, where_fn(**constants, **mapped_params)

--- a/src/gwkokab/inference/poissonlikelihood.py
+++ b/src/gwkokab/inference/poissonlikelihood.py
@@ -156,7 +156,7 @@ def poisson_likelihood(
 
             # log p(ω|data_n) - log π_n
             log_prob: Array = model_instance.log_prob(safe_data) - safe_log_ref_prior
-            log_prob = jnp.where(mask, log_prob, -jnp.inf)
+            log_prob = jnp.where(mask & (~jnp.isnan(log_prob)), log_prob, -jnp.inf)
 
             # log Σ exp (log p(ω|data_n) - log π_n)
             log_prob_sum = jax.nn.logsumexp(
@@ -196,16 +196,13 @@ def poisson_likelihood(
             name: jax.lax.dynamic_index_in_dim(x, i, keepdims=False)
             for name, i in variables_index.items()
         }
-        if where_fns is None:
-            return likelihood_fn(x, _)
-        predicate = jnp.ones((), dtype=bool)
-        for where_fn in where_fns:
+        predicate = priors.support(x)
+        for where_fn in where_fns:  # type: ignore
             predicate = jnp.logical_and(
                 predicate, where_fn(**constants, **mapped_params)
             )
         predicate = jnp.logical_and(jnp.all(x), predicate)
-        predicate = jnp.logical_and(priors.support(x), predicate)
-        return jax.lax.select(predicate, likelihood_fn(x, _), -jnp.inf)
+        return jnp.where(predicate, likelihood_fn(x, _), -jnp.inf)
 
     if where_fns is None:
         return variables_index, priors, likelihood_fn

--- a/src/gwkokab/models/spin/_models.py
+++ b/src/gwkokab/models/spin/_models.py
@@ -7,7 +7,7 @@ from typing import Optional
 from jax import lax, numpy as jnp
 from jax.typing import ArrayLike
 from numpyro.distributions import (
-    BetaProportion,
+    Beta,
     CategoricalProbs,
     constraints,
     Independent,
@@ -149,7 +149,7 @@ def BetaFromMeanVar(
     variance: ArrayLike,
     *,
     validate_args: Optional[bool] = None,
-) -> BetaProportion:
+) -> Beta:
     r"""Beta distribution parameterized by the expected value and variance.
 
     Parameters
@@ -166,8 +166,10 @@ def BetaFromMeanVar(
 
     Returns
     -------
-    BetaProportion
+    Beta
         Beta distribution with the specified mean and variance.
     """
     concentration = ((mean * (1.0 - mean)) / variance) - 1.0
-    return BetaProportion(mean, concentration, validate_args=validate_args)
+    alpha = mean * concentration
+    beta = (1.0 - mean) * concentration
+    return Beta(alpha, beta, validate_args=validate_args)

--- a/src/gwkokab/models/spin/_models.py
+++ b/src/gwkokab/models/spin/_models.py
@@ -169,6 +169,5 @@ def BetaFromMeanVar(
     BetaProportion
         Beta distribution with the specified mean and variance.
     """
-    return BetaProportion(
-        mean, (mean * (1 - mean)) / variance, validate_args=validate_args
-    )
+    concentration = ((mean * (1.0 - mean)) / variance) - 1.0
+    return BetaProportion(mean, concentration, validate_args=validate_args)

--- a/src/kokab/n_pls_m_gs/sage.py
+++ b/src/kokab/n_pls_m_gs/sage.py
@@ -277,6 +277,35 @@ def main() -> None:
             ]
         )
 
+        def tilt_scale_should_be_positive(**kwargs) -> Array:
+            if N_pl > 0:
+                scale_pl = jnp.stack(
+                    [
+                        kwargs[f"cos_tilt{i}_scale_pl_{j}"]
+                        for j in range(N_pl)
+                        for i in (1, 2)
+                    ]
+                )
+            if N_g > 0:
+                scale_g = jnp.stack(
+                    [
+                        kwargs[f"cos_tilt{i}_scale_g_{j}"]
+                        for j in range(N_g)
+                        for i in (1, 2)
+                    ]
+                )
+
+            if N_pl > 0 and N_g > 0:
+                scales = jnp.concatenate([scale_pl, scale_g])
+            elif N_pl > 0:
+                scales = scale_pl
+            else:
+                scales = scale_g
+
+            return jnp.all(scales > 0.0)
+
+        where_fns.append(tilt_scale_should_be_positive)
+
     if has_phi_12:
         parameters.append(PHI_12)
 

--- a/src/kokab/n_pls_m_gs/sage.py
+++ b/src/kokab/n_pls_m_gs/sage.py
@@ -302,7 +302,7 @@ def main() -> None:
 
             return jnp.all(scales > 0.0)
 
-        # where_fns.append(tilt_scale_should_be_positive)
+        where_fns.append(tilt_scale_should_be_positive)
 
     if has_phi_12:
         parameters.append(PHI_12)

--- a/src/kokab/n_pls_m_gs/sage.py
+++ b/src/kokab/n_pls_m_gs/sage.py
@@ -258,6 +258,7 @@ def main() -> None:
                     variances = vars_g
 
                 valid_var = variances <= means * (1 - means)
+                valid_var = jnp.logical_and(valid_var, variances > 0.0)
                 α, β = beta_dist_mean_variance_to_concentrations(means, variances)
                 valid_ab = jnp.logical_and(α > 1.0, β > 1.0)
                 return jnp.all(jnp.logical_and(valid_var, valid_ab))

--- a/src/kokab/n_pls_m_gs/sage.py
+++ b/src/kokab/n_pls_m_gs/sage.py
@@ -33,7 +33,6 @@ from gwkokab.parameters import (
     SIN_DECLINATION,
 )
 from gwkokab.poisson_mean import PoissonMean
-from gwkokab.utils.math import beta_dist_mean_variance_to_concentrations
 from gwkokab.utils.tools import error_if
 from kokab.utils import poisson_mean_parser, sage_parser
 from kokab.utils.common import (
@@ -257,11 +256,9 @@ def main() -> None:
                     means = means_g
                     variances = vars_g
 
-                valid_var = variances <= means * (1 - means)
+                valid_var = variances < means * (1.0 - means)
                 valid_var = jnp.logical_and(valid_var, variances > 0.0)
-                α, β = beta_dist_mean_variance_to_concentrations(means, variances)
-                valid_ab = jnp.logical_and(α > 1.0, β > 1.0)
-                return jnp.all(jnp.logical_and(valid_var, valid_ab))
+                return jnp.all(valid_var)
 
             where_fns.append(mean_variance_check)
 
@@ -305,7 +302,7 @@ def main() -> None:
 
             return jnp.all(scales > 0.0)
 
-        where_fns.append(tilt_scale_should_be_positive)
+        # where_fns.append(tilt_scale_should_be_positive)
 
     if has_phi_12:
         parameters.append(PHI_12)

--- a/src/kokab/n_spls_m_sgs/sage.py
+++ b/src/kokab/n_spls_m_sgs/sage.py
@@ -254,6 +254,36 @@ def main() -> None:
                 ("cos_tilt2_scale_pl", N_pl),
             ]
         )
+
+        def tilt_scale_should_be_positive(**kwargs) -> Array:
+            if N_pl > 0:
+                scale_pl = jnp.stack(
+                    [
+                        kwargs[f"cos_tilt{i}_scale_pl_{j}"]
+                        for j in range(N_pl)
+                        for i in (1, 2)
+                    ]
+                )
+            if N_g > 0:
+                scale_g = jnp.stack(
+                    [
+                        kwargs[f"cos_tilt{i}_scale_g_{j}"]
+                        for j in range(N_g)
+                        for i in (1, 2)
+                    ]
+                )
+
+            if N_pl > 0 and N_g > 0:
+                scales = jnp.concatenate([scale_pl, scale_g])
+            elif N_pl > 0:
+                scales = scale_pl
+            else:
+                scales = scale_g
+
+            return jnp.all(scales > 0.0)
+
+        where_fns.append(tilt_scale_should_be_positive)
+
     if has_eccentricity:
         parameters.append(ECCENTRICITY)
         all_params.extend(

--- a/src/kokab/n_spls_m_sgs/sage.py
+++ b/src/kokab/n_spls_m_sgs/sage.py
@@ -236,6 +236,7 @@ def main() -> None:
                     variances = vars_g
 
                 valid_var = variances <= means * (1 - means)
+                valid_var = jnp.logical_and(valid_var, variances > 0.0)
                 α, β = beta_dist_mean_variance_to_concentrations(means, variances)
                 valid_ab = jnp.logical_and(α > 1.0, β > 1.0)
                 return jnp.all(jnp.logical_and(valid_var, valid_ab))


### PR DESCRIPTION
## Summary

We were seeing scales of tilt distribution were getting negative, as a quick fix, we have added a pre-condition to check if the scales are positive. If it is true, the likelihood function will be evaluated; otherwise, $-\infty$ will be returned.


## Related To

- fixes #557 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of likelihood calculations by excluding invalid or unsupported parameter values, preventing propagation of NaN values.
  * Tightened validation of beta distribution parameters, ensuring variances are strictly positive and within valid bounds.

* **New Features**
  * Added checks to enforce that all tilt scale parameters are strictly positive when tilt parameters are enabled.

* **Refactor**
  * Updated internal logic for constructing distribution parameters and predicates, providing more explicit and stable parameterization.  
  * Changed beta distribution construction to use explicit mean and variance parameterization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->