### PR TITLE
feat(gh-135): add `SimpleRedshiftPowerlaw` distribution

### DIFF
--- a/src/gwkokab/models/__init__.py
+++ b/src/gwkokab/models/__init__.py
@@ -29,7 +29,10 @@ from .nsmoothedpowerlawmsmoothedgaussian import (
     NSmoothedPowerlawMSmoothedGaussian as NSmoothedPowerlawMSmoothedGaussian,
     SmoothedPowerlawAndPeak as SmoothedPowerlawAndPeak,
 )
-from .redshift import PowerlawRedshift as PowerlawRedshift
+from .redshift import (
+    PowerlawRedshift as PowerlawRedshift,
+    SimpleRedshiftPowerlaw as SimpleRedshiftPowerlaw,
+)
 from .spin import (
     BetaFromMeanVar as BetaFromMeanVar,
     GaussianSpinModel as GaussianSpinModel,

--- a/src/gwkokab/models/redshift/__init__.py
+++ b/src/gwkokab/models/redshift/__init__.py
@@ -2,4 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from ._models import PowerlawRedshift as PowerlawRedshift
+from ._models import (
+    PowerlawRedshift as PowerlawRedshift,
+    SimpleRedshiftPowerlaw as SimpleRedshiftPowerlaw,
+)

--- a/src/gwkokab/models/redshift/_models.py
+++ b/src/gwkokab/models/redshift/_models.py
@@ -132,7 +132,7 @@ def SimpleRedshiftPowerlaw(
     r"""Simple redshift distribution defined as,
 
     .. math::
-        p(z) \propto (1 + z)^{\kappa - 1}, \qquad 0 \leq z \leq z_{max}
+        p(z) \propto (1 + z)^{\kappa}, \qquad 0 \leq z \leq z_{max}
 
     Parameters
     ----------

--- a/src/gwkokab/models/redshift/_models.py
+++ b/src/gwkokab/models/redshift/_models.py
@@ -15,12 +15,12 @@
 
 from typing import Optional
 
-import jax.numpy as jnp
 import quadax
-from jax import Array, random
+from jax import Array, numpy as jnp, random
 from jax.lax import broadcast_shapes
 from jax.scipy.integrate import trapezoid
-from jax.typing import ArrayLike
+from jaxtyping import ArrayLike
+from numpyro import distributions as dist
 from numpyro.distributions import constraints, Distribution
 from numpyro.distributions.util import promote_shapes, validate_sample
 from numpyro.util import is_prng_key
@@ -124,3 +124,47 @@ class PowerlawRedshift(Distribution):
 
     def icdf(self, q):
         return jnp.interp(q, self.cdfgrid, self.zgrid)
+
+
+def SimpleRedshiftPowerlaw(
+    kappa: ArrayLike, z_max: ArrayLike, *, validate_args: Optional[bool] = None
+) -> dist.TransformedDistribution:
+    r"""Simple redshift distribution defined as,
+
+    .. math::
+        p(z) \propto (1 + z)^{\kappa - 1}, \qquad 0 \leq z \leq z_{max}
+
+    Parameters
+    ----------
+    kappa : ArrayLike
+        Power-law exponent :math:`\kappa`.
+    z_max : ArrayLike
+        Maximum redshift (upper limit of the support).
+    validate_args : Optional[bool], optional
+        Whether to validate arguments, by default None
+
+    Returns
+    -------
+    dist.TransformedDistribution
+        A transformed distribution representing the redshift law.
+    """
+    # We have defined this distribution in such a way that we use the available
+    # numpyro distributions and transforms. This model is similar to a powerlaw but its
+    # argument is shifted by 1.0. Therefore our support for powerlaw also shifts by 1.0.
+    low = 1.0
+    high = 1.0 + z_max
+    redshift_powerlaw = dist.DoublyTruncatedPowerLaw(
+        alpha=kappa, low=low, high=high, validate_args=validate_args
+    )
+    # Now we need to apply a shift transform to get the 1+z argument. This can be done by
+    # using an AffineTransform that shifts z by -1.0, which effectively transforms z to
+    # 1 + z.
+    shift_transform = dist.transforms.AffineTransform(
+        loc=-1.0, scale=1.0, domain=dist.constraints.interval(low, high)
+    )
+    transformed_redshift_powerlaw = dist.TransformedDistribution(
+        redshift_powerlaw,
+        transforms=[shift_transform],
+        validate_args=validate_args,
+    )
+    return transformed_redshift_powerlaw

--- a/tests/test_distributions.py
+++ b/tests/test_distributions.py
@@ -31,6 +31,7 @@ from gwkokab.models import (
     NSmoothedPowerlawMSmoothedGaussian,
     PowerlawPrimaryMassRatio,
     PowerlawRedshift,
+    SimpleRedshiftPowerlaw,
     SmoothedGaussianPrimaryMassRatio,
     SmoothedPowerlawAndPeak,
     SmoothedPowerlawPrimaryMassRatio,
@@ -600,6 +601,12 @@ CONTINUOUS = [
     ),
     (BetaFromMeanVar, {"mean": 0.4, "variance": 0.02}),
     (BetaFromMeanVar, {"mean": 0.5, "variance": 0.05}),
+    (SimpleRedshiftPowerlaw, {"z_max": 1.0, "kappa": 0.5}),
+    (SimpleRedshiftPowerlaw, {"z_max": 2.7, "kappa": -1.0}),
+    (SimpleRedshiftPowerlaw, {"z_max": 2.7, "kappa": 2.5}),
+    (SimpleRedshiftPowerlaw, {"z_max": 100.0, "kappa": 4.5}),
+    (SimpleRedshiftPowerlaw, {"z_max": 2.7, "kappa": -10.0}),
+    (SimpleRedshiftPowerlaw, {"z_max": 0.01, "kappa": 2.5}),
 ]
 
 
@@ -1046,6 +1053,8 @@ def test_log_prob_gradient(jax_dist, params):
 
     eps = 1e-3
     for i, k in enumerate(params.keys()):
+        if jax_dist is SimpleRedshiftPowerlaw and k == "z_max":
+            continue
         if jax_dist is PowerlawPrimaryMassRatio and i > 1:
             continue
         if jax_dist is Wysocki2019MassModel and i != 0:


### PR DESCRIPTION
## Summary

Implementation of a simple powerlaw to describe redshift models.

## Related To

- #135 

## Description

`PowerlawRedshift` uses comoving volume in its definition, `SimpleRedshiftPowerlaw` is same thing but without comoving volume written purely using numpyro transforms and distributions.