### PR TITLE
feat: enhance `JointDistribution` with flattening capabilities and custom support

### DIFF
--- a/src/gwkokab/models/utils/_joindistribution.py
+++ b/src/gwkokab/models/utils/_joindistribution.py
@@ -3,7 +3,7 @@
 
 
 from collections.abc import Sequence
-from typing import Optional, Tuple
+from typing import Literal, Optional, Tuple
 
 from jax import lax, numpy as jnp, random as jrd
 from jaxtyping import Array, PRNGKeyArray
@@ -11,49 +11,116 @@ from numpyro.distributions import constraints, Distribution
 from numpyro.distributions.util import validate_sample
 from numpyro.util import is_prng_key
 
-from gwkokab.models.constraints import all_constraint
+from ...utils.tools import error_if
+from ..constraints import all_constraint
 
 
 class JointDistribution(Distribution):
-    r"""Joint distribution of multiple marginal distributions."""
-
     pytree_aux_fields = ("marginal_distributions", "shaped_values")
     pytree_data_fields = ("_support",)
 
     def __init__(
         self,
         *marginal_distributions: Distribution,
+        flatten_method: Optional[Literal["deep", "shallow"]] = None,
+        support: Optional[constraints.Constraint] = None,
         validate_args: Optional[bool] = None,
     ) -> None:
-        """
+        """Construct a joint distribution from one or more marginal distributions.
+
+        You may pass individual `Distribution` instances or nest them inside
+        :class:`JointDistribution`s. The `flatten_method` argument allows flattening of nested
+        joints into a single flat list of marginals.
+
         Parameters
         ----------
-        validate_args : _type_, optional
-            Whether to validate input arguments, by default None
+        marginal_distributions : *Distribution
+            One or more `Distribution` objects (or nested :class:`JointDistribution`s) that form
+            the components of the joint distribution.
+
+        flatten_method : Optional[Literal[&quot;deep&quot;, &quot;shallow&quot;]], optional
+            If "shallow", one level of nested :class:`JointDistributions` will be flattened.
+            If "deep", all levels of nested :class:`JointDistributions` will be recursively flattened.
+            If None (default), the nesting is preserved as-is.
+
+        support : Optional[constraints.Constraint], optional
+            The constraint object representing the support of the joint distribution.
+            If not provided, it is computed from the support of the marginals.
+
+        validate_args : Optional[bool], optional
+            Whether to validate distribution parameters and inputs. Default is None.
 
         Raises
         ------
         ValueError
-            If no marginal distributions are provided.
+             If no marginal distributions are provided.
+
+
+        Example
+        -------
+        .. code::
+
+            >>> from numpyro.distributions import Normal
+            >>> from gwkokab.models.utils import JointDistribution
+
+            >>> A = Normal(0, 1)
+            >>> B = Normal(1, 1)
+            >>> C = Normal(2, 1)
+            >>> D = Normal(3, 1)
+            >>> E = Normal(4, 1)
+
+            >>> jd = JointDistribution(
+            ...     A, JointDistribution(B, JointDistribution(C, D)), E
+            ... )
+
+            >>> len(jd.marginal_distributions)  # No flattening (default)
+            3
+
+            >>> jd = JointDistribution(
+            ...     A,
+            ...     JointDistribution(B, JointDistribution(C, D)),
+            ...     E,
+            ...     flatten_method="shallow",
+            ... )
+            >>> len(jd.marginal_distributions)  # Shallow flattening
+            4
+
+            >>> jd = JointDistribution(
+            ...     A,
+            ...     JointDistribution(B, JointDistribution(C, D)),
+            ...     E,
+            ...     flatten_method="deep",
+            ... )
+            >>> len(jd.marginal_distributions)  # Deep flattening
+            5
         """
-        if not marginal_distributions:
-            raise ValueError("At least one marginal distribution is required.")
-        self.marginal_distributions = list(marginal_distributions)
+        error_if(
+            not marginal_distributions,
+            msg="At least one marginal distribution is required.",
+        )
+
+        marginal_flatten = _flatten_marginal_distributions(
+            marginal_distributions, flatten_method
+        )
+        self.marginal_distributions: Sequence[Distribution] = tuple(marginal_flatten)
         self.shaped_values: Sequence[int | Tuple[int, int]] = tuple()
         batch_shape = lax.broadcast_shapes(
-            *tuple(d.batch_shape for d in self.marginal_distributions)
+            *tuple(d.batch_shape for d in marginal_flatten)
         )
         k = 0
-        for d in self.marginal_distributions:
+        for d in marginal_flatten:
             if d.event_shape:
                 self.shaped_values += ((k, k + d.event_shape[0]),)
                 k += d.event_shape[0]
             else:
                 self.shaped_values += (k,)
                 k += 1
-        self._support = all_constraint(
-            [d.support for d in self.marginal_distributions], self.shaped_values
-        )
+        if support is None:
+            self._support = all_constraint(
+                [d.support for d in marginal_flatten], self.shaped_values
+            )
+        else:
+            self._support = support
         super(JointDistribution, self).__init__(
             batch_shape=batch_shape,
             event_shape=(k,),
@@ -90,5 +157,63 @@ class JointDistribution(Distribution):
             d.sample(k, sample_shape).reshape(*sample_shape, -1)
             for d, k in zip(self.marginal_distributions, keys)
         ]
-        samples = jnp.concatenate(samples, axis=-1)
-        return samples
+        samples_concatenated = jnp.concatenate(samples, axis=-1)
+        return samples_concatenated
+
+
+def _flatten_marginal_distributions(
+    marginal_distributions: Sequence[Distribution | JointDistribution],
+    flatten_method: Optional[Literal["deep", "shallow"]] = None,
+) -> Sequence[Distribution | JointDistribution]:
+    """Flatten marginal distributions based on the specified method.
+
+    This function converts nested :class:`JointDistribution` structures into a flat sequence
+    of `Distribution` objects, depending on the chosen `flatten_method`
+
+    Parameters
+    ----------
+    marginal_distributions : Sequence[Distribution  |  JointDistribution]
+        Sequence of Distribution or JointDistribution instances.
+    flatten_method : Optional[Literal[&quot;deep&quot;, &quot;shallow&quot;]], optional
+        If "shallow", flattens one level of nesting.\n
+        If "deep", recursively flattens all levels.\n
+        If None, returns the input as-is., by default None
+
+    Returns
+    -------
+    Sequence[Distribution | JointDistribution]
+        A flattened sequence of distributions.
+
+    Example
+    -------
+        Given:
+            JointDistribution(A, JointDistribution(B, JointDistribution(C, D)), E)
+
+        - flatten_method=None
+            => (A, JointDistribution(B, JointDistribution(C, D)), E)
+
+        - flatten_method='shallow'
+            => (A, B, JointDistribution(C, D), E)
+
+        - flatten_method='deep'
+            => (A, B, C, D, E)
+    """
+    error_if(
+        flatten_method not in (None, "deep", "shallow"),
+        msg=f"Unknown flatten method: {flatten_method}",
+    )
+    if flatten_method is None:
+        return marginal_distributions
+    flatten_dists: list[Distribution] = []
+    for m_dist in marginal_distributions:
+        if isinstance(m_dist, JointDistribution):
+            if flatten_method == "shallow":
+                m_dist_marginal_distributions = m_dist.marginal_distributions
+            else:  # deep case
+                m_dist_marginal_distributions = _flatten_marginal_distributions(
+                    m_dist.marginal_distributions, flatten_method
+                )
+            flatten_dists.extend(m_dist_marginal_distributions)
+        else:
+            flatten_dists.append(m_dist)
+    return flatten_dists

--- a/tests/gwkokab/models/utils/test_jointdistribution.py
+++ b/tests/gwkokab/models/utils/test_jointdistribution.py
@@ -1,0 +1,125 @@
+# Copyright 2023 The GWKokab Authors
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+from numpyro.distributions import Exponential, LogNormal, Normal, Uniform
+
+from gwkokab.models.utils._joindistribution import (
+    _flatten_marginal_distributions,
+    JointDistribution,
+)
+
+
+normal = Normal(0.0, 1.0)
+uniform = Uniform(0.0, 1.0)
+exponential = Exponential(1.0)
+lognormal = LogNormal(0.0, 1.0)
+
+
+def test_panic_on_empty_marginal_distributions():
+    with pytest.raises(
+        ValueError, match="At least one marginal distribution is required."
+    ):
+        JointDistribution()
+
+
+@pytest.mark.parametrize(
+    "marginal_distributions",
+    [
+        # 1. Single normal
+        (normal,),
+        # 2. Two base distributions
+        (normal, uniform),
+        # 3. Joint nested inside another
+        (JointDistribution(normal, JointDistribution(uniform, exponential)),),
+        # 4. Left-heavy deep nesting
+        (
+            JointDistribution(
+                JointDistribution(JointDistribution(normal, uniform), exponential),
+                lognormal,
+            ),
+        ),
+        # 5. Right-heavy deep nesting
+        (
+            JointDistribution(
+                normal,
+                JointDistribution(uniform, JointDistribution(exponential, lognormal)),
+            ),
+        ),
+        # 6. Multiple nested JointDists at same level
+        (
+            JointDistribution(normal, uniform),
+            JointDistribution(exponential, lognormal),
+        ),
+        # 7. Mix of atomic and nested joints
+        (
+            normal,
+            JointDistribution(uniform, exponential),
+            lognormal,
+            JointDistribution(exponential, normal),
+        ),
+        # 8. Three-layer symmetric tree
+        (
+            JointDistribution(
+                JointDistribution(normal, uniform),
+                JointDistribution(exponential, lognormal),
+            ),
+        ),
+        # 9. Deeply nested tree of only JointDistributions
+        (
+            JointDistribution(
+                JointDistribution(
+                    JointDistribution(normal, uniform),
+                    JointDistribution(exponential, lognormal),
+                ),
+                JointDistribution(lognormal, exponential),
+            ),
+        ),
+        # 10. Atomic + nested tree
+        (
+            lognormal,
+            JointDistribution(
+                JointDistribution(normal, uniform),
+                JointDistribution(exponential, lognormal),
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("flatten_method", [None, "shallow", "deep"])
+def test_flatten_marginal_distributions(marginal_distributions, flatten_method):
+    flattened = _flatten_marginal_distributions(
+        marginal_distributions, flatten_method=flatten_method
+    )
+
+    if flatten_method is None:
+        expected_len = len(marginal_distributions)
+        for i, dist in enumerate(flattened):
+            assert dist is marginal_distributions[i], (
+                f"Expected {dist} to be {marginal_distributions[i]}"
+            )
+
+    elif flatten_method == "shallow":
+        expected_len = 0
+        for dist in marginal_distributions:
+            if isinstance(dist, JointDistribution):
+                expected_len += len(dist.marginal_distributions)
+            else:
+                expected_len += 1
+
+    elif flatten_method == "deep":
+        # recursive flattening: count all underlying distributions
+        def count_all(d):
+            if isinstance(d, JointDistribution):
+                return sum(count_all(x) for x in d.marginal_distributions)
+            return 1
+
+        expected_len = sum(count_all(d) for d in marginal_distributions)
+        for dist in flattened:
+            assert not isinstance(dist, JointDistribution), (
+                "Expected no JointDistribution in deep flattening, got: " + str(dist)
+            )
+
+    assert len(flattened) == expected_len, (
+        "Flattened length mismatch for method: " + str(flatten_method)
+    )


### PR DESCRIPTION
## Summary

We have enhanced the `JointDistribution` class to simplify marginal distributions from the fact that `JointDist(A,B,JointDist(C,D),E)=JointDist(A,B,C,D,E)`. We have also kept an argument for custom support. All these changes are backward compatible.