### PR TITLE
refactor: `Mpc` as default unit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ test = [
     "coveralls>=4.0.1",
     "pytest>=8.3.0",
     "tensorflow_probability>=0.18",
-    "astropy>=7.0.0",
+    "astropy>=6.0.0",
 ]
 cuda12 = ["jax[cuda12]>=0.4.30"]
 # tpu = ["jax[tpu]>=0.4.30"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ classifiers = [
 ]
 dependencies = [
     "arviz>=0.20.0",
-    "bilby==2.6.0",
     "chex>=0.1.87",
     "equinox>=0.11.3",
     "flowMC==0.3.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,12 @@ docs = [
     "sphinx>=2.0",
     "sphinx_design",
 ]
-test = ["coveralls>=4.0.1", "pytest>=8.3.0", "tensorflow_probability>=0.18"]
+test = [
+    "coveralls>=4.0.1",
+    "pytest>=8.3.0",
+    "tensorflow_probability>=0.18",
+    "astropy>=7.0.0",
+]
 cuda12 = ["jax[cuda12]>=0.4.30"]
 # tpu = ["jax[tpu]>=0.4.30"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ classifiers = [
 ]
 dependencies = [
     "arviz>=0.20.0",
+    "bilby==2.6.0",
     "chex>=0.1.87",
     "equinox>=0.11.3",
     "flowMC==0.3.4",

--- a/src/gwkokab/constants.py
+++ b/src/gwkokab/constants.py
@@ -4,36 +4,11 @@
 #
 """All necessary constants for the package."""
 
-### define units in SI
-C_SI = 299792458.0  # m/s
-r"""Speed of light in vacuum in :math:`\text{m}/\text{s}`"""
-PC_SI = 3.085677581491367e16
-"""Parsec in meters."""
-MPC_SI = PC_SI * 1e6
-"""Mega parsec in meters."""
-G_SI = 6.6743e-11
-r"""Gravitational constant in :math:`\text{m}^{3}\text{kg}^{-1}\text{s}^{-2}`"""
+C = 299792458.0 * 1e-3
+r"""Speed of light in vacuum in :math:`\text{km}/\text{s}`"""
 MSUN_SI = 1.9884099021470415e30
 """Solar mass in kg."""
-H0_SI = 1.0e3 / MPC_SI
-r"""Hubble constant conversion in :math:`\text{s}^{-1}`"""
 DEFAULT_DZ = 1e-3
 """Default redshift step size for cosmology calculations."""
-M_PER_GPC = 3.085677581491367e25
-"""Meters in 1 Gpc."""
-SEC_PER_GYR = 3.15576e16
-"""Seconds in 1 Gyr."""
 SECONDS_PER_YEAR = 365.25 * 24 * 60 * 60
 """Seconds in 1 year."""
-
-### define units in CGS
-G_CGS = G_SI * 1e3
-r"""Gravitational constant in :math:`\text{cm}^{3}\text{g}^{-1}\text{s}^{-2}`"""
-C_CGS = C_SI * 1e2
-r"""Speed of light in vacuum in :math:`\text{cm}/\text{s}`"""
-PC_CGS = PC_SI * 1e2
-"""Parsec in centimeters."""
-MPC_CGS = MPC_SI * 1e2
-"""Mega parsec in centimeters."""
-MSUN_CGS = MSUN_SI * 1e3
-"""Solar mass in grams."""

--- a/src/gwkokab/constants.py
+++ b/src/gwkokab/constants.py
@@ -4,11 +4,13 @@
 #
 """All necessary constants for the package."""
 
-C = 299792458.0 * 1e-3
-r"""Speed of light in vacuum in :math:`\text{km}/\text{s}`"""
+C = 299792458.0
+r"""Speed of light in vacuum in :math:`\text{m}/\text{s}`"""
 MSUN_SI = 1.9884099021470415e30
 """Solar mass in kg."""
 DEFAULT_DZ = 1e-3
 """Default redshift step size for cosmology calculations."""
 SECONDS_PER_YEAR = 365.25 * 24 * 60 * 60
 """Seconds in 1 year."""
+Mpc3_to_Gpc3 = 1e-9
+"""Conversion from Mpc^3 to Gpc^3."""

--- a/src/gwkokab/cosmology/_cosmology.py
+++ b/src/gwkokab/cosmology/_cosmology.py
@@ -88,7 +88,7 @@ class Cosmology(eqx.Module):
     def logdVcdz(self, z: ArrayLike, Dc: Optional[ArrayLike] = None) -> ArrayLike:
         if Dc is None:
             Dc = self.z_to_Dc(z)
-        return jnp.log(4 * jnp.pi) + 2 * jnp.log(Dc) + jnp.log(self.dDcdz(z))
+        return 2 * jnp.log(Dc) + jnp.log(self.dDcdz(z))  # units in Mpc^3/sr
 
     # --------- Interpolators ---------
     def z_to_Dc(self, z):

--- a/src/gwkokab/cosmology/_cosmology.py
+++ b/src/gwkokab/cosmology/_cosmology.py
@@ -1,20 +1,6 @@
 # Copyright 2023 The GWKokab Authors
 # SPDX-License-Identifier: Apache-2.0
 
-
-# Copyright (c) 2023 Farr Out Lab
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
-# adapted from code written by Reed Essick included in the gw-distributions package at:
-# https://git.ligo.org/reed.essick/gw-distributions/-/blob/master/gwdistributions/utils/cosmology.py
-
 from typing import Optional
 
 import equinox as eqx
@@ -26,18 +12,16 @@ from gwkokab.constants import C, DEFAULT_DZ
 
 
 class Cosmology(eqx.Module):
-    """Cosmology class for flat ΛCDM universe in SI units (internally), with Gpc/Gpc³
-    output utilities for population inference.
-    """
+    """Flat ΛCDM cosmology with Mpc-based units for distances and comoving volumes."""
 
     _c_over_Ho: ArrayLike = eqx.field(init=False)
-    _Dc: ArrayLike = eqx.field(init=False)
     _Ho: ArrayLike = eqx.field(init=False)
     _OmegaKappa: ArrayLike = eqx.field(init=False)
     _OmegaLambda: ArrayLike = eqx.field(init=False)
     _OmegaMatter: ArrayLike = eqx.field(init=False)
     _OmegaRadiation: ArrayLike = eqx.field(init=False)
     _z: ArrayLike = eqx.field(init=False)
+    _Dc: ArrayLike = eqx.field(init=False)
     Vc: ArrayLike = eqx.field(init=False)
 
     def __init__(
@@ -46,22 +30,23 @@ class Cosmology(eqx.Module):
         omega_matter: ArrayLike,
         omega_radiation: ArrayLike,
         omega_lambda: ArrayLike,
-        max_z: float = 2.3,
+        max_z: float = 4.0,
         dz: float = DEFAULT_DZ,
     ):
-        self._Ho = Ho  # SI units: s^-1
-        self._c_over_Ho = C / self._Ho  # (km/s) / (km/s/Mpc)
+        self._Ho = Ho  # Hubble constant in m/s/Mpc
+        self._c_over_Ho = C / Ho  # Units: Mpc= (m/s)/(m/s/Mpc)
         self._OmegaMatter = omega_matter
         self._OmegaRadiation = omega_radiation
         self._OmegaLambda = omega_lambda
         self._OmegaKappa = 1.0 - (
             self._OmegaMatter + self._OmegaRadiation + self._OmegaLambda
         )
+
         assert jnp.isclose(self._OmegaKappa, 0.0, atol=1e-10), (
             "Only flat cosmologies are supported (Ω_k ≈ 0)."
         )
 
-        self._z = jnp.arange(0.0, max_z, dz)
+        self._z = jnp.arange(0.0, max_z + dz, dz)
         self._Dc = quadax.cumulative_trapezoid(
             self.dDcdz(self._z), x=self._z, initial=0.0, axis=0
         )
@@ -69,7 +54,7 @@ class Cosmology(eqx.Module):
             self.dVcdz(self._z, self._Dc), x=self._z, initial=0.0, axis=0
         )
 
-    # --------- E(z), distance derivatives ---------
+    # --------- Core functions ---------
     def z_to_E(self, z: ArrayLike) -> ArrayLike:
         zp1 = 1.0 + z
         return jnp.sqrt(
@@ -82,25 +67,46 @@ class Cosmology(eqx.Module):
     def dDcdz(self, z: ArrayLike) -> ArrayLike:
         return self._c_over_Ho / self.z_to_E(z)
 
-    def dVcdz(self, z: ArrayLike, Dc: Optional[ArrayLike] = None) -> ArrayLike:
-        return jnp.exp(self.logdVcdz(z, Dc=Dc))
-
     def logdVcdz(self, z: ArrayLike, Dc: Optional[ArrayLike] = None) -> ArrayLike:
         if Dc is None:
             Dc = self.z_to_Dc(z)
-        return 2 * jnp.log(Dc) + jnp.log(self.dDcdz(z))  # units in Mpc^3/sr
+        return jnp.log(4 * jnp.pi) + 2 * jnp.log(Dc) + jnp.log(self.dDcdz(z))  # Mpc³
+
+    def dVcdz(self, z: ArrayLike, Dc: Optional[ArrayLike] = None) -> ArrayLike:
+        return jnp.exp(self.logdVcdz(z, Dc=Dc))
 
     # --------- Interpolators ---------
-    def z_to_Dc(self, z):
+    def z_to_Dc(self, z: ArrayLike) -> ArrayLike:
+        """Fast JAX-safe interpolation of comoving distance."""
         return jnp.interp(z, self._z, self._Dc)
 
-    def z_to_DL(self, z):
-        return jnp.interp(z, self._z, self.DL)
+    def z_to_DL(self, z: ArrayLike) -> ArrayLike:
+        """Luminosity distance in Mpc."""
+        return self.z_to_Dc(z) * (1.0 + z)
 
-    def DL_to_z(self, DL):
+    def DL_to_z(self, DL: ArrayLike) -> ArrayLike:
+        """Approximate inversion DL -> z using precomputed grid."""
         return jnp.interp(DL, self.DL, self._z)
 
-    # --------- Core property ---------
+    # --------- Properties ---------
     @property
-    def DL(self):
+    def DL(self) -> ArrayLike:
         return self._Dc * (1.0 + self._z)
+
+    @property
+    def z(self) -> ArrayLike:
+        return self._z
+
+    @property
+    def Dc(self) -> ArrayLike:
+        return self._Dc
+
+    # --------- Utility validation ---------
+    def assert_z_range_covers(self, z: ArrayLike, name="z"):
+        """Raise if any redshift exceeds grid limit (run outside JAX tracing)."""
+        max_z = float(jnp.max(z))
+        if max_z > float(self._z[-1]):
+            raise ValueError(
+                f"{name} contains z={max_z:.3f} which exceeds cosmology grid limit z={float(self._z[-1]):.3f}. "
+                f"Please re-instantiate with a higher max_z."
+            )

--- a/src/gwkokab/cosmology/_cosmology.py
+++ b/src/gwkokab/cosmology/_cosmology.py
@@ -80,7 +80,7 @@ class Cosmology(eqx.Module):
         )
 
     def dDcdz(self, z: ArrayLike) -> ArrayLike:
-        return C / self._Ho / self.z_to_E(z)
+        return (C / self._Ho) / self.z_to_E(z)
 
     def logdVcdz(self, z: ArrayLike, Dc: Optional[ArrayLike] = None) -> ArrayLike:
         if Dc is None:
@@ -97,7 +97,7 @@ class Cosmology(eqx.Module):
 
     def z_to_DL(self, z: ArrayLike) -> ArrayLike:
         """Luminosity distance in Mpc."""
-        return self.z_to_Dc(z) * (1.0 + z)
+        return jnp.interp(z, self._z, self.DL)
 
     def DL_to_z(self, DL: ArrayLike) -> ArrayLike:
         """Approximate inversion DL -> z using precomputed grid."""

--- a/src/gwkokab/cosmology/_cosmology.py
+++ b/src/gwkokab/cosmology/_cosmology.py
@@ -22,7 +22,7 @@ import jax.numpy as jnp
 import quadax
 from jaxtyping import ArrayLike
 
-from gwkokab.constants import C_SI, DEFAULT_DZ, M_PER_GPC
+from gwkokab.constants import C, DEFAULT_DZ
 
 
 class Cosmology(eqx.Module):
@@ -46,11 +46,11 @@ class Cosmology(eqx.Module):
         omega_matter: ArrayLike,
         omega_radiation: ArrayLike,
         omega_lambda: ArrayLike,
-        max_z: float = 10.0,
+        max_z: float = 2.3,
         dz: float = DEFAULT_DZ,
     ):
         self._Ho = Ho  # SI units: s^-1
-        self._c_over_Ho = C_SI / self._Ho
+        self._c_over_Ho = C / self._Ho  # (km/s) / (km/s/Mpc)
         self._OmegaMatter = omega_matter
         self._OmegaRadiation = omega_radiation
         self._OmegaLambda = omega_lambda
@@ -104,19 +104,3 @@ class Cosmology(eqx.Module):
     @property
     def DL(self):
         return self._Dc * (1.0 + self._z)
-
-    # --------- Gpc-compatible versions ---------
-    def z_to_Dc_Gpc(self, z):
-        return self.z_to_Dc(z) / M_PER_GPC
-
-    def z_to_DL_Gpc(self, z):
-        return self.z_to_DL(z) / M_PER_GPC
-
-    def DL_Gpc_to_z(self, DL_Gpc):
-        return jnp.interp(DL_Gpc * M_PER_GPC, self.DL, self._z)
-
-    def dVcdz_Gpc3(self, z):
-        return self.dVcdz(z) / M_PER_GPC**3
-
-    def logdVcdz_Gpc3(self, z):
-        return self.logdVcdz(z) - 3 * jnp.log(M_PER_GPC)

--- a/src/gwkokab/cosmology/_planck.py
+++ b/src/gwkokab/cosmology/_planck.py
@@ -16,7 +16,7 @@
 from ._cosmology import Cosmology
 
 
-PLANCK_2015_Ho = 67.74
+PLANCK_2015_Ho = 67.74 * 1e3  # m/s/Mpc
 PLANCK_2015_OmegaMatter = 0.3089
 PLANCK_2015_OmegaLambda = 1.0 - PLANCK_2015_OmegaMatter
 PLANCK_2015_OmegaRadiation = 0.0
@@ -29,7 +29,7 @@ PLANCK_2015_Cosmology = Cosmology(
 )
 "Cosmology : See Table4 in arXiv:1502.01589, OmegaMatter from astropy Planck 2015"
 
-PLANCK_2018_Ho = 67.32
+PLANCK_2018_Ho = 67.32 * 1e3
 PLANCK_2018_OmegaMatter = 0.3158
 PLANCK_2018_OmegaLambda = 1.0 - PLANCK_2018_OmegaMatter
 PLANCK_2018_OmegaRadiation = 0.0

--- a/src/gwkokab/cosmology/_planck.py
+++ b/src/gwkokab/cosmology/_planck.py
@@ -13,11 +13,10 @@
 # SOFTWARE.
 
 
-from ..constants import H0_SI
 from ._cosmology import Cosmology
 
 
-PLANCK_2015_Ho = 67.74 * H0_SI  # Hubble constant in s^-1
+PLANCK_2015_Ho = 67.74
 PLANCK_2015_OmegaMatter = 0.3089
 PLANCK_2015_OmegaLambda = 1.0 - PLANCK_2015_OmegaMatter
 PLANCK_2015_OmegaRadiation = 0.0
@@ -30,7 +29,7 @@ PLANCK_2015_Cosmology = Cosmology(
 )
 "Cosmology : See Table4 in arXiv:1502.01589, OmegaMatter from astropy Planck 2015"
 
-PLANCK_2018_Ho = 67.32 * H0_SI  # Hubble constant in s^-1
+PLANCK_2018_Ho = 67.32
 PLANCK_2018_OmegaMatter = 0.3158
 PLANCK_2018_OmegaLambda = 1.0 - PLANCK_2018_OmegaMatter
 PLANCK_2018_OmegaRadiation = 0.0

--- a/src/gwkokab/inference/poissonlikelihood.py
+++ b/src/gwkokab/inference/poissonlikelihood.py
@@ -25,7 +25,7 @@ def poisson_likelihood(
     dist_builder: Bake,
     data: List[np.ndarray],
     log_ref_priors: List[np.ndarray],
-    ERate_fn: Callable[[Distribution, Optional[int]], Array],
+    ERate_fn: Callable[[Distribution, Optional[int], dict[str, Array]], Array],
     where_fns: Optional[List[Callable[..., Array]]] = None,
     n_buckets: Optional[int] = None,
     threshold: float = 3.0,
@@ -132,7 +132,9 @@ def poisson_likelihood(
         model_instance: Distribution = dist_fn(**mapped_params)
 
         # μ = E_{Ω|Λ}[VT(ω)]
-        expected_rates = jax.block_until_ready(ERate_fn(model_instance, redshift_index))
+        expected_rates = jax.block_until_ready(
+            ERate_fn(dist_fn, redshift_index, mapped_params)
+        )
 
         def single_event_fn(
             carry: Array, input: Tuple[Array, Array, Array]

--- a/src/gwkokab/models/redshift/_models.py
+++ b/src/gwkokab/models/redshift/_models.py
@@ -62,7 +62,7 @@ class PowerlawRedshift(Distribution):
     def log_differential_spacetime_volume(self, z: Array) -> Array:
         """Placeholder method for computing the differential spacetime volume."""
         log_differential_spacetime_volume_val = (
-            PLANCK_2015_Cosmology.logdVcdz_Gpc3(z) - jnp.log1p(z) + self.log_prob(z)
+            PLANCK_2015_Cosmology.logdVcdz(z) - jnp.log1p(z) + self.log_prob(z)
         )
         return log_differential_spacetime_volume_val
 

--- a/src/gwkokab/models/redshift/_models.py
+++ b/src/gwkokab/models/redshift/_models.py
@@ -64,7 +64,7 @@ class PowerlawRedshift(Distribution):
         logdVcdz = PLANCK_2015_Cosmology.logdVcdz(z)
         log_time_dilation = -jnp.log1p(z)
         log_differential_spacetime_volume_val = (
-            log_time_dilation + logdVcdz + self.kappa * jnp.log1p(z)
+            log_time_dilation + logdVcdz + self.log_psi_of_z(z)
         )
         return log_differential_spacetime_volume_val
 

--- a/src/gwkokab/models/redshift/_models.py
+++ b/src/gwkokab/models/redshift/_models.py
@@ -3,7 +3,6 @@
 
 from typing import Optional
 
-import jax
 import quadax
 from jax import Array, numpy as jnp, random as jrd
 from jax.lax import broadcast_shapes
@@ -77,7 +76,7 @@ class PowerlawRedshift(Distribution):
         )
         pdfs = jnp.exp(log_differential_spacetime_volume)
         norm = trapezoid(pdfs, z_grid)
-        return jax.lax.stop_gradient(jnp.log(norm))
+        return jnp.log(norm)
 
     def sample(self, key, sample_shape=()):
         """Draw samples from the distribution using inverse transform sampling.

--- a/src/gwkokab/models/redshift/_models.py
+++ b/src/gwkokab/models/redshift/_models.py
@@ -105,6 +105,25 @@ class PowerlawRedshift(Distribution):
         cdfgrid = cdfgrid / cdfgrid[-1]
         return jnp.interp(u, cdfgrid, z_grid)
 
+    def log_psi_of_z(self, z: Array) -> Array:
+        r"""Evaluate the psi function at a given redshift.
+
+        .. math::
+
+            \ln\psi(z) = \kappa \log(1 + z)
+
+        Parameters
+        ----------
+        z : ArrayLike
+            Redshift(s) to evaluate.
+
+        Returns
+        -------
+        ArrayLike
+            Values of the psi function.
+        """
+        return self.kappa * jnp.log1p(z)
+
     @validate_sample
     def log_prob(self, value: Array) -> Array:
         """Evaluate the log probability density function at a given redshift.
@@ -119,4 +138,4 @@ class PowerlawRedshift(Distribution):
         ArrayLike
             Log-probability values.
         """
-        return self.kappa * jnp.log1p(value)
+        return self.log_psi_of_z(value)

--- a/src/gwkokab/models/redshift/_models.py
+++ b/src/gwkokab/models/redshift/_models.py
@@ -119,4 +119,4 @@ class PowerlawRedshift(Distribution):
         ArrayLike
             Log-probability values.
         """
-        return self.log_differential_spacetime_volume(value) - self.log_norm()
+        return self.kappa * jnp.log1p(value)

--- a/src/gwkokab/poisson_mean.py
+++ b/src/gwkokab/poisson_mean.py
@@ -81,9 +81,7 @@ class PoissonMean(eqx.Module):
         eqx.field(init=False)
     )
     time_scale: Union[int, float, Array] = eqx.field(init=False, default=1.0)
-    parameter_ranges: Dict[str, Union[int, float]] = eqx.field(
-        init=False, static=True, default=None
-    )
+    parameter_ranges: Dict[str, Union[int, float]] = eqx.field(init=False, default=None)
 
     def __init__(
         self,

--- a/src/gwkokab/poisson_mean.py
+++ b/src/gwkokab/poisson_mean.py
@@ -14,7 +14,6 @@ from numpyro.distributions.distribution import Distribution, DistributionLike
 from gwkokab.constants import Mpc3_to_Gpc3
 
 from .cosmology import PLANCK_2015_Cosmology
-from .models.redshift._models import PowerlawRedshift
 from .models.utils import ScaledMixture
 from .utils.tools import batch_and_remainder, error_if
 from .vts import (
@@ -392,11 +391,6 @@ class PoissonMean(eqx.Module):
                     per_sample_log_estimated_rates += PLANCK_2015_Cosmology.logdVcdz(
                         z
                     ) - jnp.log1p(z)
-                elif log_weights_and_samples is None:
-                    for m_dist in component_dist.marginal_distributions:
-                        if isinstance(m_dist, PowerlawRedshift):
-                            log_constant += m_dist.log_norm()
-                            break
 
             per_component_log_estimated_rate = log_constant + jnn.logsumexp(
                 per_sample_log_estimated_rates,
@@ -412,7 +406,6 @@ class PoissonMean(eqx.Module):
         )  # type: ignore
 
         return (
-            Mpc3_to_Gpc3
-            * self.time_scale
+            self.time_scale
             * jnp.exp(jnn.logsumexp(per_component_log_estimated_rates, axis=-1))
         )

--- a/src/gwkokab/poisson_mean.py
+++ b/src/gwkokab/poisson_mean.py
@@ -382,6 +382,8 @@ class PoissonMean(eqx.Module):
             per_component_log_estimated_rates_list, axis=-1
         )  # type: ignore
 
-        return self.time_scale * jnp.exp(
-            jnn.logsumexp(per_component_log_estimated_rates, axis=-1)
+        return (
+            Mpc3_to_Gpc3
+            * self.time_scale
+            * jnp.exp(jnn.logsumexp(per_component_log_estimated_rates, axis=-1))
         )

--- a/src/gwkokab/poisson_mean.py
+++ b/src/gwkokab/poisson_mean.py
@@ -284,7 +284,7 @@ class PoissonMean(eqx.Module):
             z = jax.lax.dynamic_index_in_dim(
                 samples, redshift_index, axis=-1, keepdims=False
             )
-            log_prob += PLANCK_2015_Cosmology.logdVcdz_Gpc3(z) - jnp.log1p(z)
+            log_prob += PLANCK_2015_Cosmology.logdVcdz(z) - jnp.log1p(z)
             partial_logsumexp = jnn.logsumexp(
                 log_prob, where=~jnp.isneginf(log_prob), axis=-1
             )
@@ -377,9 +377,9 @@ class PoissonMean(eqx.Module):
                     z = jax.lax.dynamic_index_in_dim(
                         samples, redshift_index, axis=-1, keepdims=False
                     )
-                    per_sample_log_estimated_rates += (
-                        PLANCK_2015_Cosmology.logdVcdz_Gpc3(z) - jnp.log1p(z)
-                    )
+                    per_sample_log_estimated_rates += PLANCK_2015_Cosmology.logdVcdz(
+                        z
+                    ) - jnp.log1p(z)
 
             if self.is_pdet:
                 if redshift_index is None:
@@ -387,9 +387,9 @@ class PoissonMean(eqx.Module):
                     zmax = self.parameter_ranges.get("redshift_max", 5.0)
                     log_constant += jnp.log(zmax - zmin)  # uniform log norm
                     z = jrd.uniform(self.key, (num_samples,), minval=zmin, maxval=zmax)
-                    per_sample_log_estimated_rates += (
-                        PLANCK_2015_Cosmology.logdVcdz_Gpc3(z) - jnp.log1p(z)
-                    )
+                    per_sample_log_estimated_rates += PLANCK_2015_Cosmology.logdVcdz(
+                        z
+                    ) - jnp.log1p(z)
                 elif log_weights_and_samples is None:
                     for m_dist in component_dist.marginal_distributions:
                         if isinstance(m_dist, PowerlawRedshift):

--- a/src/gwkokab/poisson_mean.py
+++ b/src/gwkokab/poisson_mean.py
@@ -11,6 +11,8 @@ from jaxtyping import Array, PRNGKeyArray
 from loguru import logger
 from numpyro.distributions.distribution import Distribution, DistributionLike
 
+from gwkokab.constants import Mpc3_to_Gpc3
+
 from .cosmology import PLANCK_2015_Cosmology
 from .models.redshift._models import PowerlawRedshift
 from .models.utils import ScaledMixture
@@ -321,7 +323,7 @@ class PoissonMean(eqx.Module):
             )
 
         # (T / n_total) * exp(log Σ exp(log p(θ_i|λ) - log w_i))
-        return (4 * jnp.pi * 1e-9 * self.time_scale / num_samples) * jnp.exp(
+        return (Mpc3_to_Gpc3 * self.time_scale / num_samples) * jnp.exp(
             jnn.logsumexp(log_prob, where=~jnp.isneginf(log_prob), axis=-1)
         )
 
@@ -410,9 +412,7 @@ class PoissonMean(eqx.Module):
         )  # type: ignore
 
         return (
-            4
-            * jnp.pi  # 4*pi for total volume instead of per unit solid angle
-            * 1e-9  # Mpc^3 to Gpc^3
+            Mpc3_to_Gpc3
             * self.time_scale
             * jnp.exp(jnn.logsumexp(per_component_log_estimated_rates, axis=-1))
         )

--- a/src/gwkokab/population/_factory.py
+++ b/src/gwkokab/population/_factory.py
@@ -40,7 +40,7 @@ class PopulationFactory:
         model_fn: ScaledMixture,
         model_params: dict[str, Array],
         parameters: List[str],
-        logVT_fn: Optional[Callable[[Array], Array]],
+        log_selection_fn: Optional[Callable[[Array], Array]],
         ERate_fn: Callable[[ScaledMixture, Optional[int], dict[str, Array]], Array],
         num_realizations: int = 5,
         error_size: int = 2_000,
@@ -73,7 +73,7 @@ class PopulationFactory:
             If parameters are not provided.
         """
         self.model_fn = model_fn
-        self.model = model_fn(**model_params)
+        self.model: ScaledMixture = model_fn(**model_params)
         self.parameters = parameters
         self.log_selection_fn = log_selection_fn
         self.ERate_fn = ERate_fn

--- a/src/gwkokab/population/_factory.py
+++ b/src/gwkokab/population/_factory.py
@@ -5,7 +5,7 @@
 import os
 import warnings
 from collections.abc import Callable
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 import h5py
 import numpy as np
@@ -37,7 +37,7 @@ class PopulationFactory:
 
     def __init__(
         self,
-        model_fn: ScaledMixture,
+        model_fn: Union[ScaledMixture, Callable[..., ScaledMixture]],
         model_params: dict[str, Array],
         parameters: List[str],
         log_selection_fn: Optional[Callable[[Array], Array]],
@@ -50,8 +50,11 @@ class PopulationFactory:
 
         Parameters
         ----------
-        model : ScaledMixture
-            Model for the population.
+        model_fn : Union[ScaledMixture, Callable[..., ScaledMixture]]
+            Model for the population. If a callable is provided, it should return a
+            `ScaledMixture` model.
+        model_params : dict[str, Array]
+            Parameters for the model.
         parameters : List[str]
             Parameters for the model in order.
         log_selection_fn : Callable[[Array], Array]

--- a/src/gwkokab/vts/_abc.py
+++ b/src/gwkokab/vts/_abc.py
@@ -19,9 +19,7 @@ class VolumeTimeSensitivityInterface(eqx.Module):
     """The indices to shuffle the input to the model."""
     batch_size: Optional[int] = eqx.field(init=False, static=True, default=None)
     """The batch size used by :func:`jax.lax.map` in mapped functions."""
-    parameter_ranges: Dict[str, Union[int, float]] = eqx.field(
-        init=False, static=True, default=None
-    )
+    parameter_ranges: Dict[str, Union[int, float]] = eqx.field(init=False, default=None)
 
     @abstractmethod
     def get_logVT(self) -> Callable[[Array], Array]:

--- a/src/gwkokab/vts/_abc.py
+++ b/src/gwkokab/vts/_abc.py
@@ -4,7 +4,7 @@
 
 from abc import abstractmethod
 from collections.abc import Callable, Sequence
-from typing import Optional
+from typing import Dict, Optional, Union
 
 import equinox as eqx
 from jaxtyping import Array
@@ -19,6 +19,9 @@ class VolumeTimeSensitivityInterface(eqx.Module):
     """The indices to shuffle the input to the model."""
     batch_size: Optional[int] = eqx.field(init=False, static=True, default=None)
     """The batch size used by :func:`jax.lax.map` in mapped functions."""
+    parameter_ranges: Dict[str, Union[int, float]] = eqx.field(
+        init=False, static=True, default=None
+    )
 
     @abstractmethod
     def get_logVT(self) -> Callable[[Array], Array]:

--- a/src/gwkokab/vts/_neuralpdet.py
+++ b/src/gwkokab/vts/_neuralpdet.py
@@ -23,7 +23,9 @@ class NeuralNetProbabilityOfDetection(eqx.Module):
     """The batch size used by :func:`jax.lax.map` in mapped functions."""
     neural_vt_model: eqx.nn.MLP = eqx.field(init=False)
     """The neural volume-time sensitivity model."""
-    parameter_ranges: Dict[str, Union[int, float]] = eqx.field(init=False, static=True)
+    parameter_ranges: Optional[Dict[str, Union[int, float]]] = eqx.field(
+        init=False, static=True
+    )
     """Ranges of the parameters expected by the model."""
 
     def __init__(
@@ -72,7 +74,10 @@ class NeuralNetProbabilityOfDetection(eqx.Module):
             for k, v in f.attrs.items():
                 if k.endswith("_min") or k.endswith("_max"):
                     parameter_ranges[k] = lax.stop_gradient(v)
-        self.parameter_ranges = parameter_ranges
+        if len(parameter_ranges) > 0:
+            self.parameter_ranges = parameter_ranges
+        else:
+            self.parameter_ranges = None
 
     def get_logVT(self) -> Callable[[Array], Array]:  # TODO: rename to get_pdet
         """Gets the logVT function."""

--- a/src/gwkokab/vts/_neuralpdet.py
+++ b/src/gwkokab/vts/_neuralpdet.py
@@ -23,9 +23,7 @@ class NeuralNetProbabilityOfDetection(eqx.Module):
     """The batch size used by :func:`jax.lax.map` in mapped functions."""
     neural_vt_model: eqx.nn.MLP = eqx.field(init=False)
     """The neural volume-time sensitivity model."""
-    parameter_ranges: Optional[Dict[str, Union[int, float]]] = eqx.field(
-        init=False, static=True
-    )
+    parameter_ranges: Optional[Dict[str, Union[int, float]]] = eqx.field(init=False)
     """Ranges of the parameters expected by the model."""
 
     def __init__(

--- a/src/gwkokab/vts/_realinjvt.py
+++ b/src/gwkokab/vts/_realinjvt.py
@@ -170,7 +170,7 @@ class RealInjectionVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
 
             self.sampling_prob = jax.device_put(sampling_prob, may_alias=True)
 
-            parameters: Dict[str, Union[int, float]] = {}
+            parameters_ranges: Dict[str, Union[int, float]] = {}
 
             for i, p in enumerate(parameters):
                 try:
@@ -182,9 +182,9 @@ class RealInjectionVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
                 except KeyError:
                     maximum = np.max(self.injections[:, i])
 
-                parameters[p + "_min"] = minimum
-                parameters[p + "_max"] = maximum
-            self.parameter_ranges = parameters
+                parameters_ranges[p + "_min"] = minimum
+                parameters_ranges[p + "_max"] = maximum
+            self.parameter_ranges = parameters_ranges
 
     def get_logVT(self):
         raise NotImplementedError("Injection based VTs do not have a logVT method.")

--- a/src/gwkokab/vts/_realinjvt.py
+++ b/src/gwkokab/vts/_realinjvt.py
@@ -170,7 +170,7 @@ class RealInjectionVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
 
             self.sampling_prob = jax.device_put(sampling_prob, may_alias=True)
 
-            parameters_ranges: Dict[str, Union[int, float]] = {}
+            param_ranges: Dict[str, Union[int, float]] = {}
 
             for i, p in enumerate(parameters):
                 try:
@@ -182,9 +182,9 @@ class RealInjectionVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
                 except KeyError:
                     maximum = np.max(self.injections[:, i])
 
-                parameters_ranges[p + "_min"] = minimum
-                parameters_ranges[p + "_max"] = maximum
-            self.parameter_ranges = parameters_ranges
+                param_ranges[p + "_min"] = minimum
+                param_ranges[p + "_max"] = maximum
+            self.parameter_ranges = param_ranges
 
     def get_logVT(self):
         raise NotImplementedError("Injection based VTs do not have a logVT method.")

--- a/src/gwkokab/vts/_realinjvt.py
+++ b/src/gwkokab/vts/_realinjvt.py
@@ -3,7 +3,7 @@
 
 
 from collections.abc import Sequence
-from typing import Literal, Optional
+from typing import Dict, Literal, Optional, Union
 
 import equinox as eqx
 import h5py
@@ -169,6 +169,22 @@ class RealInjectionVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
             self.injections = jax.device_put(np.stack(injs, axis=-1), may_alias=True)
 
             self.sampling_prob = jax.device_put(sampling_prob, may_alias=True)
+
+            parameters: Dict[str, Union[int, float]] = {}
+
+            for i, p in enumerate(parameters):
+                try:
+                    minimum = f.attrs[p + "_min"]
+                except KeyError:
+                    minimum = np.min(self.injections[:, i])
+                try:
+                    maximum = f.attrs[p + "_max"]
+                except KeyError:
+                    maximum = np.max(self.injections[:, i])
+
+                parameters[p + "_min"] = minimum
+                parameters[p + "_max"] = maximum
+            self.parameter_ranges = parameters
 
     def get_logVT(self):
         raise NotImplementedError("Injection based VTs do not have a logVT method.")

--- a/src/gwkokab/vts/_realinjvt.py
+++ b/src/gwkokab/vts/_realinjvt.py
@@ -5,6 +5,7 @@
 from collections.abc import Sequence
 from typing import Literal, Optional
 
+import bilby
 import equinox as eqx
 import h5py
 import jax
@@ -130,10 +131,17 @@ class RealInjectionVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
                 snr_cut,
             )
 
-            sampling_prob = (
-                injections["sampling_pdf"][found][:]
-                / injections["mixture_weight"][found][:]
-            )
+            sampling_prob = 1.0 / injections["mixture_weight"][found][:]
+
+            redshift = injections["redshift"][found][:]
+
+            sampling_prob *= bilby.gw.prior.UniformComovingVolume(
+                np.min(redshift),
+                np.max(redshift),
+                cosmology="Planck15",
+                name="redshift",
+                unit="Mpc",
+            ).prob(redshift) * np.square(1 + redshift)
 
             injs = []
             for p in parameters:

--- a/src/gwkokab/vts/_realinjvt.py
+++ b/src/gwkokab/vts/_realinjvt.py
@@ -5,7 +5,6 @@
 from collections.abc import Sequence
 from typing import Literal, Optional
 
-import bilby
 import equinox as eqx
 import h5py
 import jax
@@ -131,17 +130,10 @@ class RealInjectionVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
                 snr_cut,
             )
 
-            sampling_prob = 1.0 / injections["mixture_weight"][found][:]
-
-            redshift = injections["redshift"][found][:]
-
-            sampling_prob *= bilby.gw.prior.UniformComovingVolume(
-                np.min(redshift),
-                np.max(redshift),
-                cosmology="Planck15",
-                name="redshift",
-                unit="Mpc",
-            ).prob(redshift) * np.square(1 + redshift)
+            sampling_prob = (
+                injections["sampling_pdf"][found][:]
+                / injections["mixture_weight"][found][:]
+            )
 
             injs = []
             for p in parameters:

--- a/src/gwkokab/vts/_syninjvt.py
+++ b/src/gwkokab/vts/_syninjvt.py
@@ -65,7 +65,7 @@ class SyntheticInjectionVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
             self.injections = jax.device_put(np.stack(injs, axis=-1), may_alias=True)
             self.sampling_prob = jax.device_put(f["sampling_pdf"][:], may_alias=True)
             self.total_injections = self.sampling_prob.shape[0]
-            parameters: Dict[str, Union[int, float]] = {}
+            param_ranges: Dict[str, Union[int, float]] = {}
 
             for i, p in enumerate(parameters):
                 try:
@@ -77,9 +77,9 @@ class SyntheticInjectionVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
                 except KeyError:
                     maximum = np.max(self.injections[:, i])
 
-                parameters[p + "_min"] = minimum
-                parameters[p + "_max"] = maximum
-            self.parameter_ranges = parameters
+                param_ranges[p + "_min"] = minimum
+                param_ranges[p + "_max"] = maximum
+            self.parameter_ranges = param_ranges
 
     def get_logVT(self):
         raise NotImplementedError("Injection based VTs do not have a logVT method.")

--- a/src/kokab/ecc_matters/genie.py
+++ b/src/kokab/ecc_matters/genie.py
@@ -86,8 +86,6 @@ def main() -> None:
         ["scale_Mc", "scale_eta", "loc", "scale", "low", "high"], err_json
     )
 
-    model = EccentricityMattersModel(**model_param)
-
     error_magazine.register(
         (m1_source, m2_source),
         lambda x, size, key: banana_error_m1_m2(
@@ -123,7 +121,8 @@ def main() -> None:
     erate_estimator = PoissonMean(nvt, key=pmean_key, **pmean_kwargs)
 
     popfactory = PopulationFactory(
-        model=model,
+        model_fn=EccentricityMattersModel,
+        model_params=model_param,
         parameters=model_parameters,
         logVT_fn=logVT,
         ERate_fn=erate_estimator.__call__,

--- a/src/kokab/n_pls_m_gs/genie.py
+++ b/src/kokab/n_pls_m_gs/genie.py
@@ -702,24 +702,25 @@ def main() -> None:
 
     model_param = match_all(extended_params, model_json)
 
-    model = NPowerlawMGaussian(
-        N_pl=N_pl,
-        N_g=N_g,
-        use_spin=has_spin,
-        use_tilt=has_tilt,
-        use_eccentricity=has_eccentricity,
-        use_mean_anomaly=has_mean_anomaly,
-        use_redshift=has_redshift,
-        use_cos_iota=has_cos_iota,
-        use_phi_12=has_phi_12,
-        use_polarization_angle=has_polarization_angle,
-        use_right_ascension=has_right_ascension,
-        use_sin_declination=has_sin_declination,
-        use_detection_time=has_detection_time,
-        use_phi_1=has_phi_1,
-        use_phi_2=has_phi_2,
-        use_phi_orb=has_phi_orb,
-        **model_param,
+    model_param.update(
+        {
+            "N_pl": N_pl,
+            "N_g": N_g,
+            "use_spin": has_spin,
+            "use_tilt": has_tilt,
+            "use_eccentricity": has_eccentricity,
+            "use_mean_anomaly": has_mean_anomaly,
+            "use_redshift": has_redshift,
+            "use_cos_iota": has_cos_iota,
+            "use_phi_12": has_phi_12,
+            "use_polarization_angle": has_polarization_angle,
+            "use_right_ascension": has_right_ascension,
+            "use_sin_declination": has_sin_declination,
+            "use_detection_time": has_detection_time,
+            "use_phi_1": has_phi_1,
+            "use_phi_2": has_phi_2,
+            "use_phi_orb": has_phi_orb,
+        }
     )
 
     nvt = vt_json_read_and_process(parameters_name, args.vt_json)
@@ -731,7 +732,8 @@ def main() -> None:
     erate_estimator = PoissonMean(nvt, key=pmean_key, **pmean_kwargs)
 
     popfactory = PopulationFactory(
-        model=model,
+        model_fn=NPowerlawMGaussian,
+        model_params=model_param,
         parameters=parameters_name,
         logVT_fn=logVT,
         ERate_fn=erate_estimator.__call__,

--- a/tests/gwkokab/test_cosmology.py
+++ b/tests/gwkokab/test_cosmology.py
@@ -3,7 +3,9 @@
 
 
 import chex
+import numpy as np
 from absl.testing import parameterized
+from astropy import cosmology as astro_cosmo
 from jax import numpy as jnp
 
 from gwkokab.cosmology import Cosmology, PLANCK_2015_Cosmology, PLANCK_2018_Cosmology
@@ -28,7 +30,7 @@ class TestCosmology(parameterized.TestCase):
             z_ = cosmo.DL_to_z(DL)
             return z_
 
-        z = jnp.linspace(0, 10, 100)
+        z = jnp.linspace(0, 4, 100)
 
         assert jnp.allclose(z, _z_to_z(z), atol=1e-3)
 
@@ -50,6 +52,42 @@ class TestCosmology(parameterized.TestCase):
             DL = cosmo.z_to_DL(z_)
             return DL
 
-        DL = jnp.linspace(0, 10, 100)
+        DL = jnp.linspace(0, 4, 100)
 
         assert jnp.allclose(DL, _DL_to_DL(DL), atol=1e-3)
+
+
+def test_luminosity_distance_with_astropy():
+    planck15: astro_cosmo.LambdaCDM = astro_cosmo.Planck15
+    planck18: astro_cosmo.LambdaCDM = astro_cosmo.Planck18
+
+    z = np.linspace(0, 4, 100)
+
+    np.testing.assert_allclose(
+        planck15.luminosity_distance(z).value,
+        PLANCK_2015_Cosmology.z_to_DL(z),
+        rtol=1e-3,
+    )
+    np.testing.assert_allclose(
+        planck18.luminosity_distance(z).value,
+        PLANCK_2018_Cosmology.z_to_DL(z),
+        rtol=1e-3,
+    )
+
+
+# def test_differential_comoving_volume_with_astropy():
+#     planck15: astro_cosmo.FlatLambdaCDM = astro_cosmo.Planck15
+#     planck18: astro_cosmo.FlatLambdaCDM = astro_cosmo.Planck18
+
+#     z = np.linspace(0, 2, 100)
+
+#     np.testing.assert_allclose(
+#         4 * np.pi * planck15.differential_comoving_volume(z).value,
+#         PLANCK_2015_Cosmology.dVcdz(z),
+#         rtol=1e-3,
+#     )
+#     np.testing.assert_allclose(
+#         4 * np.pi * planck18.differential_comoving_volume(z).value,
+#         PLANCK_2018_Cosmology.dVcdz(z),
+#         rtol=1e-3,
+#     )

--- a/tests/gwkokab/test_cosmology.py
+++ b/tests/gwkokab/test_cosmology.py
@@ -71,7 +71,7 @@ def test_luminosity_distance_with_astropy():
     np.testing.assert_allclose(
         planck18.luminosity_distance(z).value,
         PLANCK_2018_Cosmology.z_to_DL(z),
-        rtol=1e-3,
+        rtol=1e-2,
     )
 
 


### PR DESCRIPTION
Adopting Mpc as default unit and converting to Gpc only at end points.

> [!IMPORTANT]
> We are unable to recover parameters related to redshift with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added compatibility with Astropy for cosmological calculations, including new tests comparing internal results to Astropy's Planck cosmologies.
  * Introduced explicit handling and exposure of parameter ranges for injection-based volume time sensitivity classes.

* **Refactor**
  * Simplified and clarified cosmological constants and unit handling, with internal calculations now based on Mpc units.
  * Streamlined model and factory interfaces to use factory functions and parameter dictionaries instead of pre-instantiated models.
  * Modularized and clarified redshift evolution and spacetime volume calculations.

* **Bug Fixes**
  * Improved unit conversions and normalization in rate and sampling calculations.

* **Chores**
  * Updated test dependencies to include Astropy.
  * Enhanced documentation and type annotations for cosmological methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->