### PR TITLE
fix: remove `init=False` from fields in various classes

### DIFF
--- a/src/gwkokab/poisson_mean.py
+++ b/src/gwkokab/poisson_mean.py
@@ -69,20 +69,16 @@ class PoissonMean(eqx.Module):
     improve the performance of the importance sampling.
     """
 
-    is_injection_based: bool = eqx.field(init=False, default=False, static=True)
+    is_injection_based: bool = eqx.field(default=False, static=True)
     """Flag to check if the class is injection based or not."""
-    key: PRNGKeyArray = eqx.field(init=False)
-    logVT_estimator: Optional[VolumeTimeSensitivityInterface] = eqx.field(
-        init=False, default=None
-    )
+    key: PRNGKeyArray
+    logVT_estimator: Optional[VolumeTimeSensitivityInterface] = eqx.field(default=None)
     num_samples_per_component: Optional[List[int]] = eqx.field(
-        init=False, static=True, default=None
+        static=True, default=None
     )
-    proposal_log_weights_and_samples: Tuple[Optional[Tuple[Array, Array]], ...] = (
-        eqx.field(init=False)
-    )
-    time_scale: Union[int, float, Array] = eqx.field(init=False, default=1.0)
-    parameter_ranges: Dict[str, Union[int, float]] = eqx.field(init=False, default=None)
+    proposal_log_weights_and_samples: Tuple[Optional[Tuple[Array, Array]], ...]
+    time_scale: Union[int, float, Array] = eqx.field(default=1.0)
+    parameter_ranges: Dict[str, Union[int, float]] = eqx.field(default=None)
 
     def __init__(
         self,

--- a/src/gwkokab/vts/_abc.py
+++ b/src/gwkokab/vts/_abc.py
@@ -13,13 +13,11 @@ from jaxtyping import Array
 class VolumeTimeSensitivityInterface(eqx.Module):
     """Interface for volume time sensitivity."""
 
-    shuffle_indices: Optional[Sequence[int]] = eqx.field(
-        init=False, static=True, default=None
-    )
+    shuffle_indices: Optional[Sequence[int]] = eqx.field(static=True, default=None)
     """The indices to shuffle the input to the model."""
-    batch_size: Optional[int] = eqx.field(init=False, static=True, default=None)
+    batch_size: Optional[int] = eqx.field(static=True, default=None)
     """The batch size used by :func:`jax.lax.map` in mapped functions."""
-    parameter_ranges: Dict[str, Union[int, float]] = eqx.field(init=False, default=None)
+    parameter_ranges: Dict[str, Union[int, float]] = eqx.field(default=None)
 
     @abstractmethod
     def get_logVT(self) -> Callable[[Array], Array]:

--- a/src/gwkokab/vts/_neuralpdet.py
+++ b/src/gwkokab/vts/_neuralpdet.py
@@ -15,15 +15,13 @@ from ._utils import load_model
 
 
 class NeuralNetProbabilityOfDetection(eqx.Module):
-    shuffle_indices: Optional[Sequence[int]] = eqx.field(
-        init=False, static=True, default=None
-    )
+    shuffle_indices: Optional[Sequence[int]] = eqx.field(static=True, default=None)
     """The indices to shuffle the input to the model."""
-    batch_size: Optional[int] = eqx.field(init=False, static=True, default=None)
+    batch_size: Optional[int] = eqx.field(static=True, default=None)
     """The batch size used by :func:`jax.lax.map` in mapped functions."""
-    neural_vt_model: eqx.nn.MLP = eqx.field(init=False)
+    neural_vt_model: eqx.nn.MLP
     """The neural volume-time sensitivity model."""
-    parameter_ranges: Optional[Dict[str, Union[int, float]]] = eqx.field(init=False)
+    parameter_ranges: Optional[Dict[str, Union[int, float]]]
     """Ranges of the parameters expected by the model."""
 
     def __init__(

--- a/src/gwkokab/vts/_neuralvt.py
+++ b/src/gwkokab/vts/_neuralvt.py
@@ -17,7 +17,7 @@ from ._utils import load_model
 
 
 class NeuralNetVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
-    neural_vt_model: eqx.nn.MLP = eqx.field(init=False)
+    neural_vt_model: eqx.nn.MLP
     """The neural volume-time sensitivity model."""
 
     def __init__(

--- a/src/gwkokab/vts/_popmodelvt.py
+++ b/src/gwkokab/vts/_popmodelvt.py
@@ -55,9 +55,9 @@ def _check_and_get(name: str, f: h5py.File) -> Array:
 
 
 class PopModelsVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
-    logVT_interpolator: RegularGridInterpolator = eqx.field(init=False)
+    logVT_interpolator: RegularGridInterpolator
     """Interpolator for the log volume time sensitivity function."""
-    m_min: float = eqx.field(converter=float, init=False, static=True)
+    m_min: float = eqx.field(converter=float, static=True)
     """Minimum mass."""
 
     def __init__(
@@ -394,9 +394,9 @@ _correction_bases_aligned_spin = {
 
 
 class PopModelsCalibratedVolumeTimeSensitivity(PopModelsVolumeTimeSensitivity):
-    coeffs: Array = eqx.field(converter=jnp.asarray, init=False)
+    coeffs: Array = eqx.field(converter=jnp.asarray)
     """Coefficients for the basis functions."""
-    basis: Sequence[Callable[..., float | Array]] = eqx.field(init=False)
+    basis: Sequence[Callable[..., float | Array]]
     """Basis functions to use for the correction."""
 
     def __init__(

--- a/src/gwkokab/vts/_realinjvt.py
+++ b/src/gwkokab/vts/_realinjvt.py
@@ -5,7 +5,6 @@
 from collections.abc import Sequence
 from typing import Dict, Literal, Optional, Union
 
-import equinox as eqx
 import h5py
 import jax
 import numpy as np
@@ -35,13 +34,13 @@ _PARAM_MAPPING = {
 
 
 class RealInjectionVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
-    injections: Array = eqx.field(init=False)
+    injections: Array
     """Array of real injections of shape (n_injections, n_features)."""
-    sampling_prob: Array = eqx.field(init=False)
+    sampling_prob: Array
     """Array of sampling probabilities of shape (n_injections,)."""
-    analysis_time_years: float = eqx.field(init=False)
+    analysis_time_years: float
     """Analysis time in years."""
-    total_injections: int = eqx.field(init=False)
+    total_injections: int
     """Total number of injections.
 
     This includes both accepted and rejected injections.

--- a/src/gwkokab/vts/_semianalyticalinjvt.py
+++ b/src/gwkokab/vts/_semianalyticalinjvt.py
@@ -5,7 +5,6 @@
 from collections.abc import Sequence
 from typing import Dict, Optional, Union
 
-import equinox as eqx
 import h5py
 import jax
 import numpy as np
@@ -35,13 +34,13 @@ _PARAM_MAPPING = {
 
 
 class SemiAnalyticalRealInjectionVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
-    injections: Array = eqx.field(init=False)
+    injections: Array
     """Array of real injections of shape (n_injections, n_features)."""
-    sampling_prob: Array = eqx.field(init=False)
+    sampling_prob: Array
     """Array of sampling probabilities of shape (n_injections,)."""
-    analysis_time_years: float = eqx.field(init=False)
+    analysis_time_years: float
     """Analysis time in years."""
-    total_injections: int = eqx.field(init=False)
+    total_injections: int
     """Total number of injections.
 
     This includes both accepted and rejected injections.

--- a/src/gwkokab/vts/_syninjvt.py
+++ b/src/gwkokab/vts/_syninjvt.py
@@ -5,7 +5,6 @@
 from collections.abc import Sequence
 from typing import Dict, Optional, Union
 
-import equinox as eqx
 import h5py
 import jax
 import numpy as np
@@ -18,13 +17,13 @@ from ._abc import VolumeTimeSensitivityInterface
 
 
 class SyntheticInjectionVolumeTimeSensitivity(VolumeTimeSensitivityInterface):
-    injections: Array = eqx.field(init=False)
+    injections: Array
     """Array of real injections of shape (n_injections, n_features)."""
-    sampling_prob: Array = eqx.field(init=False)
+    sampling_prob: Array
     """Array of sampling probabilities of shape (n_injections,)."""
-    analysis_time_years: float = eqx.field(init=False)
+    analysis_time_years: float
     """Analysis time in years."""
-    total_injections: int = eqx.field(init=False)
+    total_injections: int
     """Total number of injections."""
 
     def __init__(


### PR DESCRIPTION
Removing `init=False` as per the warning from equinox, patrick-kidger/equinox@f88e62ab809140334c2f987ed13eff0d80b8be13.