### PR TITLE
fix: sort variable keys for consistent ordering in data dump and priors

### DIFF
--- a/src/gwkokab/inference/poissonlikelihood.py
+++ b/src/gwkokab/inference/poissonlikelihood.py
@@ -101,7 +101,9 @@ def poisson_likelihood(
     )
 
     constants, variables, duplicates, dist_fn = dist_builder.get_dist()  # type: ignore
-    variables_index: dict[str, int] = {key: i for i, key in enumerate(variables.keys())}
+    variables_index: dict[str, int] = {
+        key: i for i, key in enumerate(sorted(variables.keys()))
+    }
     for key, value in duplicates.items():
         variables_index[key] = variables_index[value]
 
@@ -119,7 +121,9 @@ def poisson_likelihood(
     for value in group_variables.values():  # type: ignore
         logger.debug("Recovering variable: {variable}", variable=", ".join(value))
 
-    priors = JointDistribution(*variables.values(), validate_args=True)
+    priors = JointDistribution(
+        *[variables[key] for key in sorted(variables.keys())], validate_args=True
+    )
 
     def likelihood_fn(x: Array, _: Array) -> Array:
         mapped_params = {

--- a/src/kokab/ecc_matters/sage.py
+++ b/src/kokab/ecc_matters/sage.py
@@ -113,7 +113,9 @@ def main() -> None:
     FLOWMC_HANDLER_KWARGS["nf_model_kwargs"]["n_features"] = initial_position.shape[1]
     FLOWMC_HANDLER_KWARGS["sampler_kwargs"]["n_dim"] = initial_position.shape[1]
 
-    FLOWMC_HANDLER_KWARGS["data_dump_kwargs"]["labels"] = list(model.variables.keys())
+    FLOWMC_HANDLER_KWARGS["data_dump_kwargs"]["labels"] = list(
+        sorted(model.variables.keys())
+    )
 
     FLOWMC_HANDLER_KWARGS = flowMC_default_parameters(**FLOWMC_HANDLER_KWARGS)
 

--- a/src/kokab/n_pls_m_gs/sage.py
+++ b/src/kokab/n_pls_m_gs/sage.py
@@ -515,7 +515,9 @@ def main() -> None:
     FLOWMC_HANDLER_KWARGS["nf_model_kwargs"]["n_features"] = initial_position.shape[1]
     FLOWMC_HANDLER_KWARGS["sampler_kwargs"]["n_dim"] = initial_position.shape[1]
 
-    FLOWMC_HANDLER_KWARGS["data_dump_kwargs"]["labels"] = list(model.variables.keys())
+    FLOWMC_HANDLER_KWARGS["data_dump_kwargs"]["labels"] = list(
+        sorted(model.variables.keys())
+    )
 
     FLOWMC_HANDLER_KWARGS = flowMC_default_parameters(**FLOWMC_HANDLER_KWARGS)
 

--- a/src/kokab/n_spls_m_sgs/sage.py
+++ b/src/kokab/n_spls_m_sgs/sage.py
@@ -384,7 +384,9 @@ def main() -> None:
     FLOWMC_HANDLER_KWARGS["nf_model_kwargs"]["n_features"] = initial_position.shape[1]
     FLOWMC_HANDLER_KWARGS["sampler_kwargs"]["n_dim"] = initial_position.shape[1]
 
-    FLOWMC_HANDLER_KWARGS["data_dump_kwargs"]["labels"] = list(model.variables.keys())
+    FLOWMC_HANDLER_KWARGS["data_dump_kwargs"]["labels"] = list(
+        sorted(model.variables.keys())
+    )
 
     FLOWMC_HANDLER_KWARGS = flowMC_default_parameters(**FLOWMC_HANDLER_KWARGS)
 

--- a/src/kokab/one_powerlaw_one_peak/sage.py
+++ b/src/kokab/one_powerlaw_one_peak/sage.py
@@ -194,7 +194,9 @@ def main() -> None:
     FLOWMC_HANDLER_KWARGS["nf_model_kwargs"]["n_features"] = initial_position.shape[1]
     FLOWMC_HANDLER_KWARGS["sampler_kwargs"]["n_dim"] = initial_position.shape[1]
 
-    FLOWMC_HANDLER_KWARGS["data_dump_kwargs"]["labels"] = list(model.variables.keys())
+    FLOWMC_HANDLER_KWARGS["data_dump_kwargs"]["labels"] = list(
+        sorted(model.variables.keys())
+    )
 
     FLOWMC_HANDLER_KWARGS = flowMC_default_parameters(**FLOWMC_HANDLER_KWARGS)
 

--- a/src/kokab/utils/monk.py
+++ b/src/kokab/utils/monk.py
@@ -227,7 +227,7 @@ class Monk(Guru):
         logger.debug("Baking the model")
         constants, variables, duplicates, dist_fn = self.baked_model.get_dist()  # type: ignore
         variables_index: dict[str, int] = {
-            key: i for i, key in enumerate(variables.keys())
+            key: i for i, key in enumerate(sorted(variables.keys()))
         }
         for key, value in duplicates.items():
             variables_index[key] = variables_index[value]
@@ -250,7 +250,9 @@ class Monk(Guru):
         for value in group_variables.values():  # type: ignore
             logger.debug("Recovering variable: {variable}", variable=", ".join(value))
 
-        priors = JointDistribution(*variables.values(), validate_args=True)
+        priors = JointDistribution(
+            *[variables[key] for key in sorted(variables.keys())], validate_args=True
+        )
 
         write_json("constants.json", constants)
         write_json("nf_samples_mapping.json", variables_index)
@@ -268,7 +270,9 @@ class Monk(Guru):
         ]
         flowmc_handler_kwargs["sampler_kwargs"]["n_dim"] = initial_position.shape[1]
 
-        flowmc_handler_kwargs["data_dump_kwargs"]["labels"] = list(variables.keys())
+        flowmc_handler_kwargs["data_dump_kwargs"]["labels"] = list(
+            sorted(variables.keys())
+        )
 
         flowmc_handler_kwargs = flowMC_default_parameters(**flowmc_handler_kwargs)
 


### PR DESCRIPTION
We are getting different order of values recovered in sage and monk. It hinders our ability to create overplots. We are sorting keys into alphabetical order and saving them.