### PR TITLE
fix: update key filter from "far" to "ifar" in injection processing

### DIFF
--- a/src/gwkokab/vts/_semianalyticalinjvt.py
+++ b/src/gwkokab/vts/_semianalyticalinjvt.py
@@ -96,7 +96,7 @@ class SemiAnalyticalRealInjectionVolumeTimeSensitivity(VolumeTimeSensitivityInte
             injections = f["injections"]
 
             ifar = np.max(
-                [injections[k][:] for k in injections.keys() if "far" in k],
+                [injections[k][:] for k in injections.keys() if "ifar" in k],
                 axis=0,
             )
             snr = injections["optimal_snr_net"][:]


### PR DESCRIPTION
## Summary

Typo fixed in the reading of the inverse false alarm rate of the synthetic+semi-analytic injections.

## Related To

- #560 

## Description

> [!NOTE]
> 
> GWKokab team likes to thank Asad Hussain ([@Potatoasad](https://github.com/Potatoasad)) for helping in finding out this error.
