### PR TITLE
feat(gh-135): add `SmoothedTwoComponentPrimaryMassRatio` model

### DIFF
--- a/src/gwkokab/models/__init__.py
+++ b/src/gwkokab/models/__init__.py
@@ -18,6 +18,7 @@ from ._models import (
     PowerlawPrimaryMassRatio as PowerlawPrimaryMassRatio,
     SmoothedGaussianPrimaryMassRatio as SmoothedGaussianPrimaryMassRatio,
     SmoothedPowerlawPrimaryMassRatio as SmoothedPowerlawPrimaryMassRatio,
+    SmoothedTwoComponentPrimaryMassRatio as SmoothedTwoComponentPrimaryMassRatio,
     Wysocki2019MassModel as Wysocki2019MassModel,
 )
 from .multivariate import (

--- a/src/gwkokab/models/_models.py
+++ b/src/gwkokab/models/_models.py
@@ -26,6 +26,7 @@ from ..utils.kernel import log_planck_taper_window
 from .constraints import mass_ratio_mass_sandwich, mass_sandwich
 from .utils import (
     doubly_truncated_power_law_icdf,
+    doubly_truncated_power_law_log_norm_constant,
     doubly_truncated_power_law_log_prob,
     JointDistribution,
 )
@@ -902,5 +903,172 @@ class SmoothedGaussianPrimaryMassRatio(Distribution):
             0.0,
             jnp.log(_Z_q),
         )
+        log_prob_q = self._log_prob_q(value, log_Z_q)
+        return log_prob_m1 + log_prob_q
+
+
+class SmoothedTwoComponentPrimaryMassRatio(Distribution):
+    arg_constraints = {
+        "alpha": constraints.real,
+        "beta": constraints.real,
+        "delta": constraints.positive,
+        "lambda_peak": constraints.unit_interval,
+        "loc": constraints.positive,
+        "mmax": constraints.positive,
+        "mmin": constraints.positive,
+        "scale": constraints.positive,
+    }
+    pytree_data_fields = (
+        "_logZ",
+        "_m1s",
+        "_support",
+        "_Z_q_given_m1",
+        "alpha",
+        "beta",
+        "delta",
+        "lambda_peak",
+        "loc",
+        "mmax",
+        "mmin",
+        "scale",
+    )
+
+    def __init__(
+        self,
+        alpha: ArrayLike,
+        beta: ArrayLike,
+        delta: ArrayLike,
+        lambda_peak: ArrayLike,
+        loc: ArrayLike,
+        mmax: ArrayLike,
+        mmin: ArrayLike,
+        scale: ArrayLike,
+        *,
+        validate_args=None,
+    ) -> None:
+        (
+            self.alpha,
+            self.beta,
+            self.delta,
+            self.lambda_peak,
+            self.loc,
+            self.mmax,
+            self.mmin,
+            self.scale,
+        ) = promote_shapes(
+            alpha,
+            beta,
+            delta,
+            lambda_peak,
+            loc,
+            mmax,
+            mmin,
+            scale,
+        )
+        batch_shape = lax.broadcast_shapes(
+            jnp.shape(alpha),
+            jnp.shape(beta),
+            jnp.shape(delta),
+            jnp.shape(lambda_peak),
+            jnp.shape(loc),
+            jnp.shape(mmax),
+            jnp.shape(mmin),
+            jnp.shape(scale),
+        )
+        self._support = mass_ratio_mass_sandwich(mmin, mmax)
+        super(SmoothedTwoComponentPrimaryMassRatio, self).__init__(
+            batch_shape=batch_shape, event_shape=(2,), validate_args=validate_args
+        )
+
+        mmin = jnp.broadcast_to(mmin, batch_shape)
+        mmax = jnp.broadcast_to(mmax, batch_shape)
+
+        # Compute the normalization constant for primary mass distribution
+
+        _m1s_delta = jnp.linspace(mmin, mmin + delta, 100, dtype=jnp.result_type(float))
+
+        numerical_log_norm = jnp.log(
+            jnp.trapezoid(jnp.exp(self._log_prob_m1(_m1s_delta)), _m1s_delta, axis=0)
+        )
+
+        analytical_log_norm = jnp.logaddexp(
+            jnp.log1p(-self.lambda_peak)
+            + doubly_truncated_power_law_log_norm_constant(
+                -self.alpha, self.mmin + self.delta, self.mmax
+            )
+            - doubly_truncated_power_law_log_norm_constant(
+                -self.alpha, self.mmin, self.mmax
+            ),
+            jnp.log(self.lambda_peak)
+            + jnp.log(
+                special.ndtr((self.mmax - self.loc) / self.scale)
+                - special.ndtr((self.mmin + self.delta - self.loc) / self.scale)
+            ),
+        )
+
+        self._logZ = jnp.logaddexp(numerical_log_norm, analytical_log_norm)
+
+        del _m1s_delta
+
+        # Compute the normalization constant for mass ratio distribution
+
+        self._m1s = jnp.linspace(mmin, mmax, 1000, dtype=jnp.result_type(float))
+        _qs = jnp.linspace(0.01, 1.0, 500, dtype=jnp.result_type(float))
+        _m1qs_grid = jnp.stack(jnp.meshgrid(self._m1s, _qs, indexing="ij"), axis=-1)
+
+        _prob_q = jnp.exp(self._log_prob_q(jnp.expand_dims(_m1qs_grid, axis=-2)))
+
+        self._Z_q_given_m1 = jnp.trapezoid(_prob_q, _qs, axis=1).reshape(
+            *(self._m1s.shape + batch_shape)
+        )
+        del _m1qs_grid, _qs, _prob_q
+
+    @constraints.dependent_property(is_discrete=False, event_dim=1)
+    def support(self) -> constraints.Constraint:
+        return self._support
+
+    def _log_prob_m1(self, m1: Array, logZ: ArrayLike = 0.0) -> Array:
+        log_smoothing_m1 = log_planck_taper_window((m1 - self.mmin) / self.delta)
+        log_prob_powerlaw = doubly_truncated_power_law_log_prob(
+            m1, -self.alpha, self.mmin, self.mmax
+        )
+        log_prob_norm = norm.logpdf(m1, loc=self.loc, scale=self.scale)
+        log_prob_m1 = (
+            jnp.logaddexp(
+                jnp.log1p(-self.lambda_peak) + log_prob_powerlaw,
+                jnp.log(self.lambda_peak) + log_prob_norm,
+            )
+            + log_smoothing_m1
+            - logZ
+        )
+        return jnp.nan_to_num(
+            log_prob_m1,
+            nan=-jnp.inf,
+            posinf=-jnp.inf,
+            neginf=-jnp.inf,
+        )
+
+    def _log_prob_q(self, value: Array, logZ: ArrayLike = 0.0) -> Array:
+        m1, q = jnp.unstack(value, axis=-1)
+        m2 = m1 * q
+        log_smoothing_q = log_planck_taper_window((m2 - self.mmin) / self.delta)
+        log_prob_q = self.beta * jnp.log(q) + log_smoothing_q - logZ
+        mask = self.support(value)
+        log_prob_q = jnp.where(mask, log_prob_q, -jnp.inf)
+        return jnp.nan_to_num(
+            log_prob_q,
+            nan=-jnp.inf,
+            posinf=-jnp.inf,
+            neginf=-jnp.inf,
+        )
+
+    @validate_sample
+    def log_prob(self, value: ArrayLike) -> ArrayLike:
+        m1, _ = jnp.unstack(value, axis=-1)
+        log_prob_m1 = self._log_prob_m1(m1, self._logZ)
+        _Z_q = interpax.interp1d(m1.flatten(), self._m1s, self._Z_q_given_m1).reshape(
+            m1.shape
+        )
+        log_Z_q = jnp.log(_Z_q)
         log_prob_q = self._log_prob_q(value, log_Z_q)
         return log_prob_m1 + log_prob_q

--- a/src/gwkokab/models/_models.py
+++ b/src/gwkokab/models/_models.py
@@ -1013,7 +1013,7 @@ class SmoothedTwoComponentPrimaryMassRatio(Distribution):
         # Compute the normalization constant for mass ratio distribution
 
         self._m1s = jnp.linspace(mmin, mmax, 1000, dtype=jnp.result_type(float))
-        _qs = jnp.linspace(0.01, 1.0, 500, dtype=jnp.result_type(float))
+        _qs = jnp.linspace(0.005, 1.0, 500, dtype=jnp.result_type(float))
         _m1qs_grid = jnp.stack(jnp.meshgrid(self._m1s, _qs, indexing="ij"), axis=-1)
 
         _prob_q = jnp.exp(self._log_prob_q(jnp.expand_dims(_m1qs_grid, axis=-2)))

--- a/src/gwkokab/models/nsmoothedpowerlawmsmoothedgaussian/_model.py
+++ b/src/gwkokab/models/nsmoothedpowerlawmsmoothedgaussian/_model.py
@@ -448,9 +448,7 @@ def SmoothedPowerlawAndPeak(
 
         component_distributions.append(powerlaw_z)
 
-    if len(component_distributions) == 1:
-        component_distributions = component_distributions[0]
-    else:
+    if len(component_distributions) > 1:
         component_distributions = JointDistribution(
             *component_distributions, validate_args=validate_args
         )

--- a/src/gwkokab/models/nsmoothedpowerlawmsmoothedgaussian/_model.py
+++ b/src/gwkokab/models/nsmoothedpowerlawmsmoothedgaussian/_model.py
@@ -454,7 +454,7 @@ def SmoothedPowerlawAndPeak(
         ]
 
     return ScaledMixture(
-        log_scales=params["log_rate"],
+        log_scales=jnp.asarray([params["log_rate"]]),
         component_distributions=component_distributions,
         support=component_distributions[0].support,  # type: ignore
         validate_args=validate_args,

--- a/src/gwkokab/models/nsmoothedpowerlawmsmoothedgaussian/_model.py
+++ b/src/gwkokab/models/nsmoothedpowerlawmsmoothedgaussian/_model.py
@@ -456,6 +456,6 @@ def SmoothedPowerlawAndPeak(
     return ScaledMixture(
         log_scales=params["log_rate"],
         component_distributions=component_distributions,
-        support=component_distributions.support,  # type: ignore
+        support=component_distributions[0].support,  # type: ignore
         validate_args=validate_args,
     )

--- a/src/gwkokab/models/nsmoothedpowerlawmsmoothedgaussian/_model.py
+++ b/src/gwkokab/models/nsmoothedpowerlawmsmoothedgaussian/_model.py
@@ -449,9 +449,9 @@ def SmoothedPowerlawAndPeak(
         component_distributions.append(powerlaw_z)
 
     if len(component_distributions) > 1:
-        component_distributions = JointDistribution(
-            *component_distributions, validate_args=validate_args
-        )
+        component_distributions = [
+            JointDistribution(*component_distributions, validate_args=validate_args)
+        ]
 
     return ScaledMixture(
         log_scales=params["log_rate"],

--- a/src/gwkokab/models/nsmoothedpowerlawmsmoothedgaussian/_model.py
+++ b/src/gwkokab/models/nsmoothedpowerlawmsmoothedgaussian/_model.py
@@ -401,6 +401,8 @@ def SmoothedPowerlawAndPeak(
     validate_args: Optional[bool] = None,
     **params: Array,
 ) -> ScaledMixture:
+    # NOTE: If you change something here, please also change in
+    # kokab/one_powerlaw_one_peak/ppd.py
     smoothing_model = ExtendedSupportTransformedDistribution(
         SmoothedTwoComponentPrimaryMassRatio(
             alpha=params["alpha"],

--- a/src/kokab/one_powerlaw_one_peak/ppd.py
+++ b/src/kokab/one_powerlaw_one_peak/ppd.py
@@ -11,18 +11,20 @@ from jax import numpy as jnp
 from jaxtyping import Array
 from numpyro._typing import DistributionLike
 
-from gwkokab.models import (
-    SmoothedGaussianPrimaryMassRatio,
-    SmoothedPowerlawAndPeak,
-    SmoothedPowerlawPrimaryMassRatio,
-)
-from gwkokab.models.constraints import any_constraint
+from gwkokab.models import SmoothedPowerlawAndPeak, SmoothedTwoComponentPrimaryMassRatio
 from gwkokab.models.redshift import PowerlawRedshift
 from gwkokab.models.spin import (
     BetaFromMeanVar,
     IndependentSpinOrientationGaussianIsotropic,
 )
-from gwkokab.models.utils import JointDistribution, ScaledMixture
+from gwkokab.models.transformations import (
+    PrimaryMassAndMassRatioToComponentMassesTransform,
+)
+from gwkokab.models.utils import (
+    ExtendedSupportTransformedDistribution,
+    JointDistribution,
+    ScaledMixture,
+)
 from gwkokab.parameters import Parameters
 from gwkokab.utils.tools import error_if
 from kokab.utils import ppd, ppd_parser
@@ -36,71 +38,43 @@ def SmoothedPowerlawAndPeak_raw(
     validate_args: Optional[bool] = None,
     **params: Array,
 ) -> ScaledMixture:
-    smoothed_powerlaw = SmoothedPowerlawPrimaryMassRatio(
-        alpha=params["alpha"],
-        beta=params["beta"],
-        mmin=params["mmin"],
-        mmax=params["mmax"],
-        delta=params["delta"],
-        validate_args=validate_args,
-    )
-    smoothed_gaussian = SmoothedGaussianPrimaryMassRatio(
-        loc=params["loc"],
-        scale=params["scale"],
-        beta=params["beta"],
-        mmin=params["mmin"],
-        mmax=params["mmax"],
-        delta=params["delta"],
+    smoothing_model = ExtendedSupportTransformedDistribution(
+        SmoothedTwoComponentPrimaryMassRatio(
+            alpha=params["alpha"],
+            beta=params["beta"],
+            delta=params["delta"],
+            lambda_peak=params["lambda_peak"],
+            loc=params["loc"],
+            mmax=params["mmax"],
+            mmin=params["mmin"],
+            scale=params["scale"],
+            validate_args=validate_args,
+        ),
+        transforms=PrimaryMassAndMassRatioToComponentMassesTransform(),
         validate_args=validate_args,
     )
 
-    component_distribution_pl = [smoothed_powerlaw]
-    component_distribution_g = [smoothed_gaussian]
+    component_distributions = [smoothing_model]
 
     if use_spin:
-        chi1_dist_pl = BetaFromMeanVar(
-            mean=params["chi1_mean_pl"],
-            variance=params["chi1_variance_pl"],
+        chi1_dist = BetaFromMeanVar(
+            mean=params["chi_mean"],
+            variance=params["chi_variance"],
             validate_args=validate_args,
         )
-
-        chi2_dist_pl = BetaFromMeanVar(
-            mean=params["chi2_mean_pl"],
-            variance=params["chi2_variance_pl"],
-            validate_args=validate_args,
-        )
-
-        chi1_dist_g = BetaFromMeanVar(
-            mean=params["chi1_mean_g"],
-            variance=params["chi1_variance_g"],
-            validate_args=validate_args,
-        )
-
-        chi2_dist_g = BetaFromMeanVar(
-            mean=params["chi2_mean_g"],
-            variance=params["chi2_variance_g"],
-            validate_args=validate_args,
-        )
-
-        component_distribution_pl.extend([chi1_dist_pl, chi2_dist_pl])
-        component_distribution_g.extend([chi1_dist_g, chi2_dist_g])
+        chi2_dist = chi1_dist
+        component_distributions.append(chi1_dist)
+        component_distributions.append(chi2_dist)
 
     if use_tilt:
-        tilt1_dist_pl = IndependentSpinOrientationGaussianIsotropic(
-            zeta=params["cos_tilt_zeta_pl"],
-            scale1=params["cos_tilt1_scale_pl"],
-            scale2=params["cos_tilt2_scale_pl"],
-            validate_args=validate_args,
-        )
-        tilt1_dist_g = IndependentSpinOrientationGaussianIsotropic(
-            zeta=params["cos_tilt_zeta_g"],
-            scale1=params["cos_tilt1_scale_g"],
-            scale2=params["cos_tilt2_scale_g"],
+        tilt_dist = IndependentSpinOrientationGaussianIsotropic(
+            zeta=params["cos_tilt_zeta"],
+            scale1=params["cos_tilt_scale"],
+            scale2=params["cos_tilt_scale"],
             validate_args=validate_args,
         )
 
-        component_distribution_pl.append(tilt1_dist_pl)
-        component_distribution_g.append(tilt1_dist_g)
+        component_distributions.append(tilt_dist)
 
     if use_redshift:
         z_max = params["z_max"]
@@ -109,37 +83,17 @@ def SmoothedPowerlawAndPeak_raw(
             z_max=z_max, kappa=kappa, validate_args=validate_args
         )
 
-        component_distribution_pl.append(powerlaw_z)
-        component_distribution_g.append(powerlaw_z)
+        component_distributions.append(powerlaw_z)
 
-    if len(component_distribution_pl) == 1:
-        component_distribution_pl = component_distribution_pl[0]
-    else:
-        component_distribution_pl = JointDistribution(
-            *component_distribution_pl, validate_args=validate_args
-        )
+    if len(component_distributions) > 1:
+        component_distributions = [
+            JointDistribution(*component_distributions, validate_args=validate_args)
+        ]
 
-    if len(component_distribution_g) == 1:
-        component_distribution_g = component_distribution_g[0]
-    else:
-        component_distribution_g = JointDistribution(
-            *component_distribution_g, validate_args=validate_args
-        )
     return ScaledMixture(
-        log_scales=jnp.stack(
-            [
-                params["log_rate"] + jnp.log1p(-params["lambda_peak"]),  # type: ignore[arg-type, operator]
-                params["log_rate"] + jnp.log(params["lambda_peak"]),  # type: ignore[arg-type]
-            ],
-            axis=-1,
-        ),
-        component_distributions=[component_distribution_pl, component_distribution_g],
-        support=any_constraint(
-            [
-                component_distribution_pl.support,  # type: ignore[attr-defined]
-                component_distribution_g.support,  # type: ignore[attr-defined]
-            ]
-        ),
+        log_scales=jnp.asarray([params["log_rate"]]),
+        component_distributions=component_distributions,
+        support=component_distributions[0].support,  # type: ignore
         validate_args=validate_args,
     )
 

--- a/src/kokab/one_powerlaw_one_peak/sage.py
+++ b/src/kokab/one_powerlaw_one_peak/sage.py
@@ -112,29 +112,11 @@ class SmoothedPowerlawAndPeakCore(Sage):
         ]
 
         if self.has_spin:
-            model_parameters.extend(
-                [
-                    "chi1_mean_g",
-                    "chi1_mean_pl",
-                    "chi1_variance_g",
-                    "chi1_variance_pl",
-                    "chi2_mean_g",
-                    "chi2_mean_pl",
-                    "chi2_variance_g",
-                    "chi2_variance_pl",
-                ]
-            )
+            model_parameters.extend(["chi_mean", "chi_variance"])
 
         if self.has_tilt:
             model_parameters.extend(
-                [
-                    "cos_tilt_zeta_g",
-                    "cos_tilt_zeta_pl",
-                    "cos_tilt1_scale_g",
-                    "cos_tilt1_scale_pl",
-                    "cos_tilt2_scale_g",
-                    "cos_tilt2_scale_pl",
-                ]
+                ["cos_tilt_zeta", "cos_tilt1_scale", "cos_tilt2_scale"]
             )
 
         if self.has_redshift:

--- a/src/kokab/one_powerlaw_one_peak/sage.py
+++ b/src/kokab/one_powerlaw_one_peak/sage.py
@@ -115,9 +115,7 @@ class SmoothedPowerlawAndPeakCore(Sage):
             model_parameters.extend(["chi_mean", "chi_variance"])
 
         if self.has_tilt:
-            model_parameters.extend(
-                ["cos_tilt_zeta", "cos_tilt1_scale", "cos_tilt2_scale"]
-            )
+            model_parameters.extend(["cos_tilt_zeta", "cos_tilt_scale"])
 
         if self.has_redshift:
             model_parameters.extend(["kappa", "z_max"])


### PR DESCRIPTION
## Summary
Correct implementation of the PowerLaw+Peak model from GWTC-3.

## Related To

- #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a unified two‑component, smoothed primary‑mass plus mass‑ratio distribution for faster evaluation.
  - Introduced a SimpleRedshiftPowerlaw distribution with bounded support.
  - Exposed the new mass‑ratio model in the public API.

- Refactor
  - Consolidated mass components into a single path with one log_rate and simplified mixture construction.
  - Unified spin parameters to chi_mean and chi_variance.
  - Unified tilt parameters to cos_tilt_zeta and cos_tilt_scale (and per‑component scales where applicable).
  - Streamlined model assembly by deriving support from the first component and reducing duplicated component lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->