### PR TITLE
feat: add Hamiltonian Monte Carlo in `flowMC` interface

### DIFF
--- a/src/kokab/core/flowMC_based.py
+++ b/src/kokab/core/flowMC_based.py
@@ -761,7 +761,7 @@ class FlowMCBased(Guru):
         global_thinning = bundle_config["global_thinning"]
         learning_rate = bundle_config["learning_rate"]
         local_thinning = bundle_config["local_thinning"]
-        local_sampler_name = bundle_config.get("local_sampler_name", "mala")
+        local_sampler_name: str = bundle_config.get("local_sampler_name", "mala")
         step_size = bundle_config["step_size"]
         condition_matrix = bundle_config.get("condition_matrix", 1.0)
         n_leapfrog = bundle_config.get("n_leapfrog", 10)
@@ -823,6 +823,12 @@ class FlowMCBased(Guru):
         error_if(
             not all(isinstance(x, int) and x > 0 for x in rq_spline_hidden_units),
             msg=f"expected a list of positive integers, got {rq_spline_hidden_units} for rq_spline_hidden_units",
+        )
+
+        valid_local_samplers = ("mala", "hmc")
+        error_if(
+            local_sampler_name.strip().lower() not in valid_local_samplers,
+            msg="local_sampler_name must be one of " + ", ".join(valid_local_samplers),
         )
 
         initial_position = priors.sample(self.rng_key, (n_chains,))


### PR DESCRIPTION
Refactoring `RQSpline_MALA_Bundle` to optionally select Hamiltonian Monte Carlo.

`RQSpline_MALA_Bundle` and `mala_step_size` in flowMC configuration has been renamed to `bundle_config` and `step_size` respectively.

To choose between MALA and HMC, provide `local_sampler_name` in `bundle_config`; valid `local_sampler_name` are `mala` (default) and `hmc`.

`step_size` is shared between MALA and HMC and there are two more paramters `n_leapfrog`; number of steps for leapforg integrator, and `condition_matrix`; condition matrix which can either be positive scalar, vector of size equal to number of features with positive entries, or square matrix of size number of features which should be positive definite (all eigne values should be positive).