### PR TITLE
chore(gh-454): refactor log likelihood calculations and improve masking in Poisson likelihood functions

### DIFF
--- a/src/kokab/core/sage.py
+++ b/src/kokab/core/sage.py
@@ -142,15 +142,24 @@ class Sage(Guru):
             data, log_ref_priors, n_buckets=self.n_buckets, threshold=self.threshold
         )
 
+        for i in range(self.n_buckets):
+            _log_ref_priors_group[i] = np.where(  # type: ignore
+                _masks_group[i], _log_ref_priors_group[i], 0.0
+            )
+
         _data_group = tuple(_data_group)
         _log_ref_priors_group = tuple(_log_ref_priors_group)
         _masks_group = tuple(_masks_group)
 
-        data_group: Tuple[Array] = jax.block_until_ready(jax.device_put(_data_group))
-        log_ref_priors_group: Tuple[Array] = jax.block_until_ready(
+        data_group: Tuple[Array, ...] = jax.block_until_ready(
+            jax.device_put(_data_group)
+        )
+        log_ref_priors_group: Tuple[Array, ...] = jax.block_until_ready(
             jax.device_put(_log_ref_priors_group)
         )
-        masks_group: Tuple[Array] = jax.block_until_ready(jax.device_put(_masks_group))
+        masks_group: Tuple[Array, ...] = jax.block_until_ready(
+            jax.device_put(_masks_group)
+        )
 
         logger.debug(
             "data_group.shape: {shape}",

--- a/src/kokab/utils/jenks.py
+++ b/src/kokab/utils/jenks.py
@@ -12,7 +12,7 @@ processing large datasets.
 """
 
 from collections.abc import Sequence
-from typing import Optional, TypeVar, Union
+from typing import Optional, Tuple, TypeVar, Union
 
 import jenkspy
 import numpy as np
@@ -293,7 +293,7 @@ def pad_and_stack(
     *arrays: Sequence[Union[Array, np.ndarray]],
     n_buckets: Optional[int],
     threshold: float,
-) -> Sequence[Sequence[Array]]:
+) -> Tuple[Sequence[Array], ...]:
     """Pad and stack multiple arrays into buckets.
 
     Parameters
@@ -310,7 +310,7 @@ def pad_and_stack(
 
     Returns
     -------
-    Sequence[Sequence[Array]]
+    Tuple[Sequence[Array], ...]
         A sequence of padded arrays, where each array corresponds to a bucket.
         The last element of the sequence is a mask indicating which elements are valid
         and which are padded.
@@ -338,4 +338,4 @@ def pad_and_stack(
     ]
     masks = [_bucket_mask(s) for s in subsets_arrays[0]]
 
-    return padded_subsets + [masks]
+    return tuple(padded_subsets + [masks])


### PR DESCRIPTION
## Summary

Avoiding `jax.lax.scan`, by sequentially mapping the computationally heavy log prob.

## Related To

- #454 