### PR TITLE
fix: remove upper pin from JAX

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "matplotlib>=3.9.0",
     "mplcursors>=0.6",
     "numpy<3",
-    "numpyro>=0.19.0",
+    "numpyro>=0.21.0",
     "optax<0.2.7",
     "pandas>=2.2.0",
     "pydantic>=2.12.0",
@@ -79,10 +79,10 @@ keywords = [
 ]
 
 [project.optional-dependencies]
-cpu = ["jax>=0.7.0,<0.10.0"]
-cuda12 = ["jax[cuda12]>=0.7.0,<0.10.0"]
-cuda13 = ["jax[cuda13]>=0.7.0,<0.10.0"]
-tpu = ["jax[tpu]>=0.7.0,<0.10.0"]
+cpu = ["jax>=0.10.0"]
+cuda12 = ["jax[cuda12]>=0.10.0"]
+cuda13 = ["jax[cuda13]>=0.10.0"]
+tpu = ["jax[tpu]>=0.10.0"]
 
 [dependency-groups]
 dev = ["prek>=0.2.30", "ruff>=0.8.0", "setuptools>=75.6.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
     "matplotlib>=3.9.0",
     "mplcursors>=0.6",
     "numpy<3",
-    "numpyro>=0.21.0",
+    "numpyro>=0.19.0",
     "optax<0.2.7",
     "pandas>=2.2.0",
     "pydantic>=2.12.0",
@@ -79,10 +79,10 @@ keywords = [
 ]
 
 [project.optional-dependencies]
-cpu = ["jax>=0.10.0"]
-cuda12 = ["jax[cuda12]>=0.10.0"]
-cuda13 = ["jax[cuda13]>=0.10.0"]
-tpu = ["jax[tpu]>=0.10.0"]
+cpu = ["jax>=0.7.0"]
+cuda12 = ["jax[cuda12]>=0.7.0"]
+cuda13 = ["jax[cuda13]>=0.7.0"]
+tpu = ["jax[tpu]>=0.7.0"]
 
 [dependency-groups]
 dev = ["prek>=0.2.30", "ruff>=0.8.0", "setuptools>=75.6.0"]


### PR DESCRIPTION
Updating the version of JAX and NumPyro, because https://github.com/pyro-ppl/numpyro/pull/2173 has been merged along with a new numpyro release.