### PR TITLE
feat(inference): sample-mode (likelihood-mode) Poisson population lik…

### DIFF
--- a/examples/sampled_likelihood_demo.py
+++ b/examples/sampled_likelihood_demo.py
@@ -1,0 +1,134 @@
+# Copyright 2023 The GWKokab Authors
+# SPDX-License-Identifier: Apache-2.0
+
+r"""Demo: sample-mode (likelihood-mode) population inference end to end.
+
+Runs the test-problem sequence of ``demo/PLAN_gwkokab_sampled_likelihood.md``
+on a closed-form Gaussian problem and finishes with a **real numpyro NUTS run**
+that recovers the population mean from samples drawn from the model — the
+opposite of gwkokab's density mode, and the path a particle Monte-Carlo
+population engine takes natively (draws + weights, no grid, no KDE).
+
+Usage
+-----
+    export PYTHONPATH=src:.            # + RIFT stub in a lightweight sandbox
+    python examples/sampled_likelihood_demo.py --n-events 150 --num-samples 400
+
+The numpyro NUTS section is the heavy one; reduce ``--num-samples`` /
+``--n-events`` for a quick smoke test.  Everything else runs in a few seconds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+
+import jax
+import jax.numpy as jnp
+
+from gwkokab.inference.event_likelihoods import gaussian_event_log_likelihoods
+from gwkokab.inference.poissonlikelihood_utils import (
+    low_ess_events,
+    sampled_poisson_likelihood_fn,
+)
+
+
+jax.config.update("jax_enable_x64", True)
+
+M_TRUE, S_TRUE, LOGR_TRUE, T_OBS = 1.0, 0.8, math.log(120.0), 2.0
+
+
+def draw_catalog(key, n_events, sigma_obs=0.3):
+    k1, k2 = jax.random.split(key)
+    x_true = M_TRUE + S_TRUE * jax.random.normal(k1, (n_events,))
+    d = (x_true + sigma_obs * jax.random.normal(k2, (n_events,)))[:, None]
+    sigma = jnp.full((n_events,), sigma_obs)
+    return d, sigma
+
+
+def model_sampler(m, s, log_rate, z):
+    samples = m + s * z
+    log_w = jnp.full((z.shape[0],), log_rate - math.log(z.shape[0]))
+    return samples, log_w
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--n-events", type=int, default=150)
+    ap.add_argument("--n-model-samples", type=int, default=40_000)
+    ap.add_argument("--num-warmup", type=int, default=300)
+    ap.add_argument("--num-samples", type=int, default=400)
+    ap.add_argument("--skip-nuts", action="store_true")
+    args = ap.parse_args()
+
+    d, sigma = draw_catalog(jax.random.PRNGKey(0), args.n_events)
+    Ls = gaussian_event_log_likelihoods(d, (sigma**2)[:, None, None])
+    z = jax.random.normal(jax.random.PRNGKey(1), (args.n_model_samples, 1))
+
+    # --- diagnostics at the truth ---------------------------------------- #
+    samples, log_w = model_sampler(M_TRUE, S_TRUE, LOGR_TRUE, z)
+    ll, diag = sampled_poisson_likelihood_fn(Ls, samples, log_w, None, T_OBS, None)
+    flagged = low_ess_events(diag["ess_per_event"], args.n_model_samples, frac=0.1)
+    print(f"log L at truth         : {float(ll):+.3f}")
+    print(f"expected detected count: {float(diag['expected_rate']):.2f}")
+    print(f"median per-event ESS   : {float(jnp.median(diag['ess_per_event'])):.0f}"
+          f" / {args.n_model_samples}")
+    print(f"low-ESS (tail) events  : {len(flagged)}")
+
+    # --- MAP recovery via gradient ascent through the sampler ------------- #
+    def loglik(m):
+        s_, log_w_ = model_sampler(m, S_TRUE, LOGR_TRUE, z)
+        out, _ = sampled_poisson_likelihood_fn(Ls, s_, log_w_, None, T_OBS, None)
+        return out
+
+    vg = jax.jit(jax.value_and_grad(loglik))
+    m = jnp.asarray(M_TRUE + 0.8)
+    for _ in range(400):
+        _, g = vg(m)
+        m = m + 3e-3 * g
+    print(f"MAP (grad-ascent) mean : {float(m):.3f}   (truth {M_TRUE})")
+
+    if args.skip_nuts:
+        return
+
+    # --- full numpyro NUTS posterior ------------------------------------- #
+    import numpyro
+    import numpyro.distributions as dist
+    from numpyro.infer import MCMC, NUTS
+    from gwkokab.inference.numpyro_sampled_poisson_likelihood import (
+        numpyro_sampled_poisson_likelihood,
+    )
+    from gwkokab.models.utils import JointDistribution
+
+    def sampler_fn(loc_pop, log_rate, scale_pop):
+        return model_sampler(loc_pop, scale_pop, log_rate, z)
+
+    variables = {"loc_pop": dist.Normal(0.0, 3.0)}
+    priors = JointDistribution(dist.Normal(0.0, 3.0))
+    model = numpyro_sampled_poisson_likelihood(
+        sampler_fn,
+        priors,
+        variables,
+        {"log_rate": LOGR_TRUE, "scale_pop": S_TRUE},
+        {"loc_pop": 0},
+        Ls,
+        None,
+        None,
+    )
+
+    mcmc = MCMC(
+        NUTS(model),
+        num_warmup=args.num_warmup,
+        num_samples=args.num_samples,
+        progress_bar=True,
+    )
+    mcmc.run(jax.random.PRNGKey(2), T_OBS)
+    post = mcmc.get_samples()["loc_pop"]
+    print(
+        f"NUTS posterior loc_pop : {float(jnp.mean(post)):.3f} "
+        f"+/- {float(jnp.std(post)):.3f}   (truth {M_TRUE})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sampled_likelihood_method.md
+++ b/examples/sampled_likelihood_method.md
@@ -1,0 +1,79 @@
+# Sample-mode (likelihood-mode) population inference
+
+GWKokab's two established likelihoods evaluate the population model as a
+**pointwise density** `p(x | θ)` at samples drawn from each event's posterior
+(`analytical_poisson_likelihood_fn`, `discrete_poisson_likelihood_fn`). That
+requires the model to expose a density — fine for closed-form mixtures, but a
+hard wall for population models that are only available as **weighted Monte-Carlo
+draws** (e.g. a hierarchical-merger coagulation engine). Reconstructing a density
+from those draws means KDE, which over-smooths narrow features.
+
+`sampled_poisson_likelihood_fn` is the dual. It evaluates a per-event
+**likelihood** `L_i(x)` at samples drawn from the **model**, using the other
+direction of the same importance-sampling identity for the per-event term of the
+inhomogeneous-Poisson likelihood:
+
+```
+I_i(θ) = ∫ L_i(x) n(x|θ) dx ≈ Σ_j w_j L_i(x_j),     x_j ~ n(·|θ)
+```
+
+where `n(x|θ)` is the merger **rate density (intensity)** and the weights carry
+its normalisation (`Σ_j w_j ≈ ∫ n dx =` total rate). The assembled
+log-likelihood mirrors the analytical form exactly,
+
+```
+log L(θ) = Σ_i log I_i + n_events·log T_obs − μ(θ),
+μ(θ) = T_obs · Σ_j w_j p_det(x_j)         (sample-based selection)
+```
+
+so with one model sample, flat selection and `T_obs = 1` it reduces to the same
+single-event Poisson term the analytical path produces — a framework-standard
+generalisation, not a new estimator. Because the samples and weights come from a
+reparameterised JAX sampler, `jax.grad` of `log L` w.r.t. the population
+parameters θ is well defined: the per-event draw probabilities become continuous,
+differentiable quantities, enabling gradient-based inference and model selection
+directly through the sample traces.
+
+## What's provided
+
+| piece | where |
+|---|---|
+| core estimator + per-event ESS / variance diagnostics | `gwkokab.inference.sampled_poisson_likelihood_fn`, `low_ess_events` |
+| numpyro / flowMC wrappers (`sampler_fn(**params) -> (samples, log_w)` replaces `dist_fn`) | `numpyro_sampled_poisson_likelihood`, `flowMC_sampled_poisson_likelihood`; `factory.get_likelihood_fn(..., "sampled")` |
+| per-event likelihood adapters | `GaussianEventLikelihood` (CI reference), `RIFTMarginalLikelihood` (production interpolant interface) |
+| graded test-problem sequence (TP0–TP4) | `tests/test_sampled_poisson_likelihood.py` |
+| end-to-end NUTS recovery demo | `examples/sampled_likelihood_demo.py` |
+
+The public API is **additive** — the two density modes are untouched; the only
+swaps in the new wrappers are `dist_fn → sampler_fn` and "model density at event
+samples" → "event likelihoods at model samples". The same
+`priors / variables / variables_index` `sorted`-order plumbing applies.
+
+## Acceptance gates (closed-form Gaussian problem)
+
+A Gaussian population intensity with Gaussian per-event likelihoods has a
+closed-form per-event evidence `I_i = R · N(d_i; m, √(σ_i²+s²))`, so each gate is
+checked against an exact reference:
+
+* **TP0** — `Σ_j w_j L_i(x_j)` recovers the closed-form `I_i` within MC error.
+* **TP1 (gate i)** — the sampled log-likelihood matches both the exact value and
+  the existing `analytical_poisson_likelihood_fn` within MC error, across a grid
+  of θ. The two modes are the same identity evaluated from opposite directions.
+* **TP2 (gate ii)** — `jax.grad` through the sampler is finite and matches a
+  **many-key finite-difference mean**, not a single-key FD (single-key FD is not
+  a valid reference once the sampler carries stochastic selection — see the
+  engine's `feedback_single_key_fd_not_ad_reference`).
+* **TP3 (gate iii)** — an event in the tail of `n(·|θ)` collapses its effective
+  sample size; `low_ess_events` flags it. The variance term is **not optional**
+  when events can sit in the tail; stratified / weighted model proposals target
+  the under-populated regions.
+* **TP4** — gradient ascent through the sampler recovers the true population
+  mean, and a real numpyro NUTS run recovers its posterior.
+
+## Thread-back to a population engine
+
+The production adapter is `RIFTMarginalLikelihood`: wrap a per-event RIFT
+marginal-likelihood interpolant as an `L_i`, supply the engine's particle-MC
+draws + weights as `sampler_fn`, and the population is constrained directly from
+model samples — no grid, no KDE. That engine-side wiring is the next increment
+(see `demo/PLAN_gwkokab_sampled_likelihood.md`).

--- a/src/gwkokab/inference/__init__.py
+++ b/src/gwkokab/inference/__init__.py
@@ -17,7 +17,20 @@ from .numpyro_analytical_poisson_likelihood import (
 from .numpyro_discrete_poisson_likelihood import (
     numpyro_discrete_poisson_likelihood as numpyro_discrete_poisson_likelihood,
 )
+from .flowMC_sampled_poisson_likelihood import (
+    flowMC_sampled_poisson_likelihood as flowMC_sampled_poisson_likelihood,
+)
+from .numpyro_sampled_poisson_likelihood import (
+    numpyro_sampled_poisson_likelihood as numpyro_sampled_poisson_likelihood,
+)
+from .event_likelihoods import (
+    GaussianEventLikelihood as GaussianEventLikelihood,
+    RIFTMarginalLikelihood as RIFTMarginalLikelihood,
+    gaussian_event_log_likelihoods as gaussian_event_log_likelihoods,
+)
 from .poissonlikelihood_utils import (
     analytical_poisson_likelihood_fn as analytical_poisson_likelihood_fn,
     discrete_poisson_likelihood_fn as discrete_poisson_likelihood_fn,
+    low_ess_events as low_ess_events,
+    sampled_poisson_likelihood_fn as sampled_poisson_likelihood_fn,
 )

--- a/src/gwkokab/inference/__init__.py
+++ b/src/gwkokab/inference/__init__.py
@@ -23,6 +23,9 @@ from .flowMC_sampled_poisson_likelihood import (
 from .numpyro_sampled_poisson_likelihood import (
     numpyro_sampled_poisson_likelihood as numpyro_sampled_poisson_likelihood,
 )
+from .numpyro_mixed_poisson_likelihood import (
+    numpyro_mixed_poisson_likelihood as numpyro_mixed_poisson_likelihood,
+)
 from .event_likelihoods import (
     GaussianEventLikelihood as GaussianEventLikelihood,
     RIFTMarginalLikelihood as RIFTMarginalLikelihood,

--- a/src/gwkokab/inference/event_likelihoods.py
+++ b/src/gwkokab/inference/event_likelihoods.py
@@ -1,0 +1,150 @@
+# Copyright 2023 The GWKokab Authors
+# SPDX-License-Identifier: Apache-2.0
+
+r"""Per-event log-likelihood evaluators for the sample-mode population likelihood.
+
+:func:`gwkokab.inference.poissonlikelihood_utils.sampled_poisson_likelihood_fn`
+consumes one duck-typed callable per event,
+
+    ``L_i: (n_samples, n_dim) -> (n_samples,)``  (log-likelihood values),
+
+evaluated at samples drawn from the population model.  This module provides
+
+* :class:`GaussianEventLikelihood` / :func:`gaussian_event_log_likelihoods` — an
+  analytic multivariate-normal event likelihood used as the closed-form CI
+  reference (the analytical-Poisson path and the sample path then agree exactly
+  in the large-sample limit; see the TP1 acceptance gate).
+* :class:`RIFTMarginalLikelihood` — the production adapter interface: it wraps a
+  per-event RIFT marginal-likelihood **interpolant** (a callable produced by the
+  RIFT pipeline) as an ``L_i``.  This is the thread-back hook; the interpolant
+  itself is loaded engine-side and is intentionally not built here.
+"""
+
+from collections.abc import Sequence
+from typing import Callable
+
+import jax
+from jax import numpy as jnp
+from jaxtyping import Array
+
+
+__all__ = [
+    "GaussianEventLikelihood",
+    "gaussian_event_log_likelihoods",
+    "RIFTMarginalLikelihood",
+]
+
+
+class GaussianEventLikelihood:
+    r"""Analytic multivariate-normal per-event log-likelihood.
+
+    ``L_i(x) = log N(x; mean, cov)``.  With a Gaussian population intensity the
+    per-event evidence ``I_i = ∫ L_i(x) n(x|θ) dx`` is available in closed form,
+    which is what makes this the exact CI reference for the two likelihood modes.
+
+    Parameters
+    ----------
+    mean : Array
+        ``(n_dim,)`` event central value.
+    cov : Array
+        ``(n_dim, n_dim)`` covariance, or ``(n_dim,)`` diagonal, or scalar
+        (isotropic) measurement covariance.
+    """
+
+    def __init__(self, mean: Array, cov: Array):
+        self.mean = jnp.atleast_1d(jnp.asarray(mean, dtype=float))
+        n_dim = self.mean.shape[0]
+        cov = jnp.asarray(cov, dtype=float)
+        if cov.ndim == 0:
+            cov = cov * jnp.eye(n_dim)
+        elif cov.ndim == 1:
+            cov = jnp.diag(cov)
+        self.cov = cov
+
+    def __call__(self, samples: Array) -> Array:
+        samples = jnp.atleast_2d(samples)
+        return jax.scipy.stats.multivariate_normal.logpdf(
+            samples, self.mean, self.cov
+        )
+
+
+def gaussian_event_log_likelihoods(
+    means: Array,
+    covs: Array,
+) -> tuple[GaussianEventLikelihood, ...]:
+    r"""Build a tuple of :class:`GaussianEventLikelihood` for a mock catalogue.
+
+    Parameters
+    ----------
+    means : Array
+        ``(n_events, n_dim)`` per-event central values.
+    covs : Array
+        ``(n_events, n_dim, n_dim)`` covariances, or ``(n_events, n_dim)``
+        diagonals, or ``(n_events,)`` isotropic scalars.
+
+    Returns
+    -------
+    tuple of GaussianEventLikelihood
+        One evaluator per event, ready to pass as ``event_log_likelihood_fns``.
+    """
+    means = jnp.atleast_2d(means)
+    n_events = means.shape[0]
+    return tuple(
+        GaussianEventLikelihood(means[i], covs[i]) for i in range(n_events)
+    )
+
+
+class RIFTMarginalLikelihood:
+    r"""Adapter wrapping a per-event RIFT marginal-likelihood interpolant.
+
+    The production path of ``demo/PLAN_gwkokab_sampled_likelihood.md``: RIFT
+    produces, per event, an interpolant / fit of the marginal likelihood over
+    the binary parameters ``x``.  Wrapping that interpolant as an ``L_i`` lets
+    the population be constrained directly from model **samples**, with no
+    model density and no KDE.
+
+    This class is the **interface only** — pass an already-built interpolant
+    callable (engine-side loading lives in the bridge, per the thread-back
+    increment).  ``interpolant`` must accept ``(n_samples, n_dim)`` and return
+    ``(n_samples,)`` *log* marginal-likelihood values; if it returns linear
+    likelihood, set ``log_input=False`` and it is logged here.
+
+    Parameters
+    ----------
+    interpolant : Callable
+        The per-event RIFT interpolant, ``(n_samples, n_dim) -> (n_samples,)``.
+    log_input : bool, default True
+        Whether ``interpolant`` already returns log-likelihood.
+    """
+
+    def __init__(self, interpolant: Callable[[Array], Array], log_input: bool = True):
+        if not callable(interpolant):
+            raise TypeError(
+                "RIFTMarginalLikelihood requires a callable per-event interpolant "
+                "(n_samples, n_dim) -> (n_samples,). Build it from the RIFT fit "
+                "engine-side and pass it here."
+            )
+        self.interpolant = interpolant
+        self.log_input = log_input
+
+    def __call__(self, samples: Array) -> Array:
+        values = self.interpolant(jnp.atleast_2d(samples))
+        return values if self.log_input else jnp.log(values)
+
+
+def stack_event_log_likelihoods(
+    event_log_likelihood_fns: Sequence[Callable[[Array], Array]],
+) -> Callable[[Array], Array]:
+    r"""Optional helper: fold a tuple of evaluators into one batched callable.
+
+    Returns ``L: (n_samples, n_dim) -> (n_events, n_samples)`` by stacking the
+    per-event evaluators.  Useful when every event shares the same functional
+    form and a single ``vmap`` is cheaper than the Python loop; the core
+    likelihood accepts either the tuple or — via a one-line wrapper around this
+    — a batched form.
+    """
+
+    def batched(samples: Array) -> Array:
+        return jnp.stack([L_i(samples) for L_i in event_log_likelihood_fns], axis=0)
+
+    return batched

--- a/src/gwkokab/inference/factory.py
+++ b/src/gwkokab/inference/factory.py
@@ -19,20 +19,30 @@ from gwkokab.inference.numpyro_analytical_poisson_likelihood import (
 from gwkokab.inference.numpyro_discrete_poisson_likelihood import (
     numpyro_discrete_poisson_likelihood as numpyro_discrete_poisson_likelihood,
 )
+from gwkokab.inference.flowMC_sampled_poisson_likelihood import (
+    flowMC_sampled_poisson_likelihood as flowMC_sampled_poisson_likelihood,
+)
+from gwkokab.inference.numpyro_sampled_poisson_likelihood import (
+    numpyro_sampled_poisson_likelihood as numpyro_sampled_poisson_likelihood,
+)
 from gwkokab.utils.exceptions import LoggedValueError
 
 
 def get_likelihood_fn(
     sampler_name: Literal["flowMC", "numpyro"],
-    analysis_type: Literal["discrete", "analytical"],
+    analysis_type: Literal["discrete", "analytical", "sampled"],
 ) -> Callable[..., Callable]:
     if sampler_name == "flowMC":
         if analysis_type == "analytical":
             return flowMC_analytical_poisson_likelihood
+        if analysis_type == "sampled":
+            return flowMC_sampled_poisson_likelihood
         return flowMC_discrete_poisson_likelihood
     if sampler_name == "numpyro":
         if analysis_type == "analytical":
             return numpyro_analytical_poisson_likelihood
+        if analysis_type == "sampled":
+            return numpyro_sampled_poisson_likelihood
         return numpyro_discrete_poisson_likelihood
 
     raise LoggedValueError(

--- a/src/gwkokab/inference/flowMC_sampled_poisson_likelihood.py
+++ b/src/gwkokab/inference/flowMC_sampled_poisson_likelihood.py
@@ -1,0 +1,76 @@
+# Copyright 2023 The GWKokab Authors
+# SPDX-License-Identifier: Apache-2.0
+
+
+from collections.abc import Callable, Sequence
+from typing import Any, Dict
+
+import jax
+from jax import numpy as jnp
+from jaxtyping import Array
+
+from gwkokab.inference.poissonlikelihood_utils import (
+    sampled_poisson_likelihood_fn,
+)
+from gwkokab.models.utils import JointDistribution
+
+
+__all__ = ["flowMC_sampled_poisson_likelihood"]
+
+
+def flowMC_sampled_poisson_likelihood(
+    sampler_fn: Callable[..., tuple[Array, Array]],
+    priors: JointDistribution,
+    variables: Dict[str, Any],
+    constant_params: Dict[str, Any],
+    variables_index: Dict[str, int],
+    event_log_likelihood_fns: Sequence[Callable[[Array], Array]],
+    pdet_fn: Callable[[Array], Array] | None,
+    variance_cut_threshold: float | None,
+) -> Callable[[Array, Dict[str, Any]], Array]:
+    r"""Sample-mode (likelihood-mode) flowMC population log-posterior.
+
+    The dual of :func:`flowMC_analytical_poisson_likelihood`: the population
+    model is supplied as a ``sampler_fn(**params) -> (samples, log_weights)``
+    and the per-event terms are evaluated by a per-event **likelihood** rather
+    than a model **density**.  ``data["T_obs"]`` is read at call time, mirroring
+    how the analytical wrapper reads ``data["samples_stack"]`` etc.; the event
+    evaluators and ``pdet_fn`` are static and bound at construction.
+    """
+    del variables
+
+    def _map_params(x: Array) -> Dict[str, Array]:
+        return {
+            name: jax.lax.dynamic_index_in_dim(x, i, keepdims=False)
+            for name, i in variables_index.items()
+        }
+
+    def log_posterior_fn(x: Array, data: Dict[str, Any]) -> Array:
+        T_obs = data["T_obs"]
+
+        mapped_params = _map_params(x)
+        model_samples, model_log_weights = sampler_fn(
+            **constant_params, **mapped_params
+        )
+
+        log_likelihood, _diagnostics = sampled_poisson_likelihood_fn(
+            event_log_likelihood_fns,
+            model_samples,
+            model_log_weights,
+            pdet_fn,
+            T_obs,
+            variance_cut_threshold,
+        )
+
+        log_posterior = priors.log_prob(x) + log_likelihood
+
+        log_posterior = jnp.nan_to_num(
+            log_posterior,
+            nan=-jnp.inf,
+            posinf=-jnp.inf,
+            neginf=-jnp.inf,
+        )
+
+        return log_posterior
+
+    return log_posterior_fn

--- a/src/gwkokab/inference/numpyro_mixed_poisson_likelihood.py
+++ b/src/gwkokab/inference/numpyro_mixed_poisson_likelihood.py
@@ -1,0 +1,120 @@
+# Copyright 2023 The GWKokab Authors
+# SPDX-License-Identifier: Apache-2.0
+
+
+from collections.abc import Callable, Sequence
+from typing import Any, Dict, Tuple
+
+import jax
+import numpyro
+from jax import numpy as jnp
+from jaxtyping import Array
+from numpyro.distributions import Distribution
+
+from gwkokab.inference.poissonlikelihood_utils import (
+    mixed_poisson_likelihood_fn,
+)
+from gwkokab.models.utils import JointDistribution, LazyJointDistribution
+
+
+__all__ = ["numpyro_mixed_poisson_likelihood"]
+
+
+def numpyro_mixed_poisson_likelihood(
+    sampler_fn: Callable[..., tuple[Array, Array]],
+    dist_fn: Callable[..., Distribution] | None,
+    priors: JointDistribution,
+    variables: Dict[str, Distribution],
+    constant_params: Dict[str, Any],
+    variables_index: Dict[str, int],
+    *,
+    event_log_likelihood_fns: Sequence[Callable[[Array], Array]],
+    data_group: Tuple[Array, ...] = (),
+    log_ref_priors_group: Tuple[Array, ...] = (),
+    masks_group: Tuple[Array, ...] = (),
+    N_pes: Tuple[Array, ...] = (),
+    pdet_fn: Callable[[Array], Array] | None = None,
+    variance_cut_threshold: float | None = None,
+) -> Callable[[Array], None]:
+    r"""Mixed-mode numpyro population likelihood (sampled + discrete, one μ).
+
+    Binds BOTH a ``sampler_fn(**params) -> (samples, log_weights)`` (the model as
+    weighted draws — used for the broad/high-mass **sampled** group and for the
+    shared Poisson mean μ) AND a ``dist_fn(**params) -> Distribution`` (the model
+    *density* — used for the narrow/low-mass **discrete** group's posterior-sample
+    reweighting).  A coagulation engine supplies both from one solve at θ
+    (``make_coagulation_sampler_fn`` / ``make_coagulation_dist_fn``).  Prior
+    plumbing is identical to :func:`numpyro_sampled_poisson_likelihood`; the only
+    additions are ``dist_fn`` and the discrete-group event arrays.  Public API is
+    additive; the single-mode wrappers are untouched.
+
+    ``dist_fn`` may be ``None`` when ``data_group`` is empty (all events broad),
+    in which case this reduces exactly to the sampled wrapper.
+
+    See :func:`gwkokab.inference.poissonlikelihood_utils.mixed_poisson_likelihood_fn`
+    for the estimator and the per-event-ESS split criterion.
+    """
+    if is_lazy_prior := isinstance(priors, LazyJointDistribution):
+        dependencies = priors.dependencies
+        partial_order = priors.partial_order
+    del priors
+
+    sorted_variables = sorted(variables.items(), key=lambda x: x[0])
+
+    def log_likelihood_fn(T_obs: Array):
+        if is_lazy_prior:
+            partial_variables_samples = [
+                numpyro.sample(parameter_name, prior_dist)
+                if isinstance(prior_dist, Distribution)
+                else (parameter_name, prior_dist)
+                for parameter_name, prior_dist in sorted_variables
+            ]
+            for i in partial_order:
+                kwargs = {
+                    k: partial_variables_samples[v] for k, v in dependencies[i].items()
+                }
+                parameter_name, prior_dist_fn = partial_variables_samples[i]
+                if isinstance(prior_dist_fn, jax.tree_util.Partial):
+                    prior_dist = prior_dist_fn.func(
+                        *prior_dist_fn.args, **prior_dist_fn.keywords, **kwargs
+                    )  # type: ignore[arg-type]
+                else:
+                    prior_dist = prior_dist_fn  # type: ignore[assignment]
+                partial_variables_samples[i] = numpyro.sample(parameter_name, prior_dist)
+            variables_samples = partial_variables_samples  # type: ignore[assignment]
+        else:
+            variables_samples = [
+                numpyro.sample(parameter_name, prior_dist)
+                for parameter_name, prior_dist in sorted_variables
+            ]
+
+        mapped_params = {
+            name: variables_samples[i] for name, i in variables_index.items()
+        }
+
+        # Same population θ in both representations.
+        model_samples, model_log_weights = sampler_fn(**constant_params, **mapped_params)
+        model_instance = (
+            dist_fn(**constant_params, **mapped_params) if dist_fn is not None else None
+        )
+
+        log_likelihood, _diagnostics = mixed_poisson_likelihood_fn(
+            event_log_likelihood_fns,
+            model_samples,
+            model_log_weights,
+            pdet_fn,
+            model_instance,
+            data_group,
+            log_ref_priors_group,
+            masks_group,
+            N_pes,
+            T_obs,
+            variance_cut_threshold,
+        )
+
+        log_likelihood = jnp.nan_to_num(
+            log_likelihood, nan=-jnp.inf, posinf=-jnp.inf, neginf=-jnp.inf
+        )
+        numpyro.factor("log_likelihood", log_likelihood)
+
+    return log_likelihood_fn  # type: ignore[return-value]

--- a/src/gwkokab/inference/numpyro_sampled_poisson_likelihood.py
+++ b/src/gwkokab/inference/numpyro_sampled_poisson_likelihood.py
@@ -1,0 +1,139 @@
+# Copyright 2023 The GWKokab Authors
+# SPDX-License-Identifier: Apache-2.0
+
+
+from collections.abc import Callable, Sequence
+from typing import Any, Dict
+
+import jax
+import numpyro
+from jax import numpy as jnp
+from jaxtyping import Array
+from numpyro.distributions import Distribution
+
+from gwkokab.inference.poissonlikelihood_utils import (
+    sampled_poisson_likelihood_fn,
+)
+from gwkokab.models.utils import JointDistribution, LazyJointDistribution
+
+
+__all__ = ["numpyro_sampled_poisson_likelihood"]
+
+
+def numpyro_sampled_poisson_likelihood(
+    sampler_fn: Callable[..., tuple[Array, Array]],
+    priors: JointDistribution,
+    variables: Dict[str, Distribution],
+    constant_params: Dict[str, Any],
+    variables_index: Dict[str, int],
+    event_log_likelihood_fns: Sequence[Callable[[Array], Array]],
+    pdet_fn: Callable[[Array], Array] | None,
+    variance_cut_threshold: float | None,
+) -> Callable[[Array], None]:
+    r"""Sample-mode (likelihood-mode) numpyro population likelihood.
+
+    The dual of :func:`numpyro_analytical_poisson_likelihood`.  Where the
+    analytical wrapper binds a ``dist_fn(**params) -> Distribution`` (a pointwise
+    model **density**) and is handed each event's PE samples, this wrapper binds
+    a ``sampler_fn(**params) -> (samples, log_weights)`` (the model as weighted
+    **draws**) and is handed a per-event **likelihood evaluator** for each event.
+    This is what a particle Monte-Carlo population engine supplies natively — no
+    grid, no KDE — see ``demo/PLAN_gwkokab_sampled_likelihood.md``.
+
+    Plumbing is identical to the analytical path: the same ``priors`` /
+    ``variables`` / ``variables_index`` ``sorted``-order contract maps numpyro
+    prior draws onto the model's keyword arguments.  The only swaps are
+    ``dist_fn → sampler_fn`` and (model density at event samples) → (event
+    likelihoods at model samples).  Public API is additive; the two density
+    modes are untouched.
+
+    Parameters
+    ----------
+    sampler_fn : Callable
+        ``(**constant_params, **mapped_params) -> (samples, log_weights)`` with
+        ``samples`` shape ``(n_samples, n_dim)`` and ``log_weights`` shape
+        ``(n_samples,)``.  Must be reparameterised (AD-traceable) for gradients.
+    priors, variables, constant_params, variables_index
+        As in :func:`numpyro_analytical_poisson_likelihood`.
+    event_log_likelihood_fns : Sequence[Callable]
+        One ``L_i: (n_samples, n_dim) -> (n_samples,)`` log-likelihood evaluator
+        per event (the "data").  Bound at construction (they are static,
+        per-analysis objects); the returned model takes only ``T_obs``.
+    pdet_fn : Callable or None
+        Detection-probability evaluator for the sample-based Poisson mean; ``None``
+        ⇒ flat selection ``VT ≡ 1``.
+    variance_cut_threshold : float or None
+        Optional importance-sampling variance tapering.
+
+    Returns
+    -------
+    Callable
+        ``log_likelihood_fn(T_obs)`` — a numpyro model registering
+        ``numpyro.factor("log_likelihood", ...)``.
+    """
+    if is_lazy_prior := isinstance(priors, LazyJointDistribution):
+        dependencies = priors.dependencies
+        partial_order = priors.partial_order
+    del priors
+
+    sorted_variables = sorted(variables.items(), key=lambda x: x[0])
+
+    def log_likelihood_fn(T_obs: Array):
+        if is_lazy_prior:
+            partial_variables_samples = [
+                numpyro.sample(parameter_name, prior_dist)
+                if isinstance(prior_dist, Distribution)
+                else (parameter_name, prior_dist)
+                for parameter_name, prior_dist in sorted_variables
+            ]
+
+            for i in partial_order:
+                kwargs = {
+                    k: partial_variables_samples[v] for k, v in dependencies[i].items()
+                }
+                parameter_name, prior_dist_fn = partial_variables_samples[i]
+                if isinstance(prior_dist_fn, jax.tree_util.Partial):
+                    prior_dist = prior_dist_fn.func(
+                        *prior_dist_fn.args, **prior_dist_fn.keywords, **kwargs
+                    )  # type: ignore[arg-type]
+                else:
+                    prior_dist = prior_dist_fn  # type: ignore[assignment]
+                partial_variables_samples[i] = numpyro.sample(
+                    parameter_name, prior_dist
+                )
+
+            variables_samples = partial_variables_samples  # type: ignore[assignment]
+        else:
+            variables_samples = [
+                numpyro.sample(parameter_name, prior_dist)
+                for parameter_name, prior_dist in sorted_variables
+            ]
+
+        mapped_params = {
+            name: variables_samples[i] for name, i in variables_index.items()
+        }
+
+        # The model as weighted draws, instead of a pointwise density.
+        model_samples, model_log_weights = sampler_fn(
+            **constant_params, **mapped_params
+        )
+
+        log_likelihood, _diagnostics = sampled_poisson_likelihood_fn(
+            event_log_likelihood_fns,
+            model_samples,
+            model_log_weights,
+            pdet_fn,
+            T_obs,
+            variance_cut_threshold,
+        )
+
+        log_likelihood = jnp.nan_to_num(
+            log_likelihood,
+            nan=-jnp.inf,
+            posinf=-jnp.inf,
+            neginf=-jnp.inf,
+        )
+
+        numpyro.factor("log_likelihood", log_likelihood)
+
+    return log_likelihood_fn  # type: ignore[return-value]

--- a/src/gwkokab/inference/poissonlikelihood_utils.py
+++ b/src/gwkokab/inference/poissonlikelihood_utils.py
@@ -15,6 +15,7 @@ __all__ = [
     "discrete_poisson_likelihood_fn",
     "analytical_poisson_likelihood_fn",
     "sampled_poisson_likelihood_fn",
+    "mixed_poisson_likelihood_fn",
     "low_ess_events",
 ]
 
@@ -297,6 +298,149 @@ def sampled_poisson_likelihood_fn(
         "log_evidence_per_event": log_I,
         "ess_per_event": ess,
         "rel_variance_per_event": rel_variance,
+        "expected_rate": expected_rate,
+    }
+    return log_likelihood, diagnostics
+
+
+def mixed_poisson_likelihood_fn(
+    # ---- sampled (continuous-L) group: broad / high-mass events --------------
+    event_log_likelihood_fns: Sequence[Callable[[Array], Array]],
+    model_samples: Array,
+    model_log_weights: Array,
+    pdet_fn: Callable[[Array], Array] | None,
+    # ---- discrete (posterior-sample) group: narrow / low-mass events ---------
+    model_instance: Distribution | None,
+    data_group: Tuple[Array, ...],
+    log_ref_priors_group: Tuple[Array, ...],
+    masks_group: Tuple[Array, ...],
+    N_pes: Tuple[Array, ...],
+    # ---- shared --------------------------------------------------------------
+    T_obs: Array,
+    variance_cut_threshold: float | None,
+) -> Tuple[Array, Dict[str, Array]]:
+    r"""Mixed-mode inhomogeneous-Poisson population likelihood.
+
+    Combines, in ONE Poisson likelihood with a SINGLE shared Poisson mean
+    ``μ(θ)``, two per-event representations of the SAME population ``θ``:
+
+    * a **sampled** group (``event_log_likelihood_fns`` evaluated at the model's
+      own draws ``model_samples`` — the :func:`sampled_poisson_likelihood_fn`
+      term), for events with a usable continuous per-event likelihood ``L_i``
+      and healthy importance ESS against the draws (broad / high-mass /
+      hierarchical events); and
+    * a **discrete** group (each event's posterior samples reweighted against the
+      model *density* ``model_instance.log_prob`` — the
+      :func:`discrete_poisson_likelihood_fn` term), for events whose continuous
+      ``L_i`` is unavailable or whose sampled ESS collapses (narrow / low-mass
+      events).
+
+    Both representations must be evaluated at the **same** ``θ``; a coagulation
+    engine supplies both natively — ``sampler_fn(θ) -> (model_samples,
+    model_log_weights)`` and ``dist_fn(θ) -> model_instance`` (its implicit-grid
+    density) — cross-calibrated to the same cascade depth.  The per-event split
+    is chosen by the **sampled-estimator ESS** (use sampled where ESS > 4·N_obs,
+    else discrete); see :func:`low_ess_events`.
+
+    The assembled likelihood mirrors both single-mode forms exactly, sharing one
+    ``μ``:
+
+    .. math::
+
+        \log\mathcal{L} = \sum_{i\in S}\log\mathcal{I}^{\mathrm{samp}}_i
+                        + \sum_{i\in D}\log\mathcal{I}^{\mathrm{disc}}_i
+                        + n_\mathrm{events}\log T_\mathrm{obs} - \mu(\theta),
+
+    with ``μ = T_obs Σ_j w_j p_det(x_j)`` computed **once** from the model draws
+    (the sample-based convention of :func:`sampled_poisson_likelihood_fn`; ``μ``
+    is a population property, independent of the event partition).  Limits:
+    an empty discrete group reproduces :func:`sampled_poisson_likelihood_fn`
+    exactly; an empty sampled group reproduces the per-event sum + shared ``μ``
+    of the discrete path (with the sample-based ``μ`` in place of the
+    estimator-based one).
+
+    Returns ``(log_likelihood, diagnostics)`` where diagnostics carries
+    ``ess_per_event_sampled`` / ``ess_per_event_discrete`` (concatenated where
+    meaningful), ``log_evidence_per_event_sampled`` /
+    ``log_evidence_per_event_discrete`` and the scalar ``expected_rate`` ``μ``.
+    """
+    # ---- sampled group: I_i = Σ_j w_j L_i(x_j)  (broad events) ---------------
+    log_w = model_log_weights
+    n_samples = log_w.shape[0]
+    n_sampled = len(event_log_likelihood_fns)
+
+    log_I_s_list = []
+    log_sq_s_list = []
+    for L_i in event_log_likelihood_fns:
+        a = log_w + L_i(model_samples)  # (n_samples,)
+        log_I_s_list.append(jax.nn.logsumexp(a))
+        log_sq_s_list.append(jax.nn.logsumexp(2.0 * a))
+    if n_sampled > 0:
+        log_I_s = jnp.stack(log_I_s_list)
+        log_sq_s = jnp.stack(log_sq_s_list)
+        ess_s = jnp.exp(2.0 * log_I_s - log_sq_s)
+        rel_var_s = jnp.exp(log_sq_s - 2.0 * log_I_s) - 1.0 / n_samples
+        total_ln_l_s = jnp.sum(log_I_s)
+    else:
+        log_I_s = jnp.zeros((0,))
+        ess_s = jnp.zeros((0,))
+        rel_var_s = jnp.zeros((0,))
+        total_ln_l_s = jnp.zeros(())
+
+    # ---- discrete group: I_i = (1/M_i) Σ_k exp(log ρ(y) − log π)  (narrow) ---
+    n_discrete = sum(int(d.shape[0]) for d in data_group)
+    total_ln_l_d = -jnp.sum(jnp.asarray([jnp.log(N_pe).sum() for N_pe in N_pes])) \
+        if len(N_pes) > 0 else jnp.zeros(())  # − Σ log M_i
+    pe_variance = jnp.zeros(())
+    log_I_d_list = []
+    if n_discrete > 0:
+        assert model_instance is not None, "discrete group requires model_instance"
+        for batched_data, batched_log_ref_priors, batched_mask, N_pe in zip(
+            data_group, log_ref_priors_group, masks_group, N_pes
+        ):
+            feasible_point = model_instance.support.feasible_like(batched_data[0])
+            safe_data = jnp.where(
+                batched_mask[..., jnp.newaxis], batched_data, feasible_point
+            )
+            batch_model_log_prob = model_instance.log_prob(safe_data)
+            log_prob = batch_model_log_prob - batched_log_ref_priors
+            log_prob = jnp.where(batched_mask, log_prob, -jnp.inf)
+            log_prob_sum = jax.nn.logsumexp(log_prob, axis=-1)  # (n_in_batch,)
+            log_prob_sum_2 = jax.nn.logsumexp(2.0 * log_prob, axis=-1)
+            total_ln_l_d += log_prob_sum.sum(axis=0, initial=0.0)
+            pe_variance += (
+                jnp.exp(log_prob_sum_2 - 2.0 * log_prob_sum) - 1.0 / N_pe
+            ).sum()
+            # per-event log evidence (incl. the −log M_i normalisation)
+            log_I_d_list.append(log_prob_sum - jnp.log(N_pe))
+    log_I_d = jnp.concatenate(log_I_d_list) if log_I_d_list else jnp.zeros((0,))
+
+    n_events = n_sampled + n_discrete
+
+    # ---- shared Poisson mean μ = T_obs Σ_j w_j pdet(x_j) (sample-based) ------
+    if pdet_fn is None:
+        log_mu = jnp.log(T_obs) + jax.nn.logsumexp(log_w)
+    else:
+        log_pdet = jnp.log(pdet_fn(model_samples))
+        log_mu = jnp.log(T_obs) + jax.nn.logsumexp(log_w + log_pdet)
+    expected_rate = jnp.exp(log_mu)
+
+    log_likelihood = (
+        total_ln_l_s + total_ln_l_d + n_events * jnp.log(T_obs) - expected_rate
+    )
+
+    if variance_cut_threshold is not None:
+        total_variance = jnp.nan_to_num(
+            jnp.sum(rel_var_s) + pe_variance,
+            nan=jnp.inf, posinf=jnp.inf, neginf=jnp.inf,
+        )
+        log_likelihood -= variance_tapering_fn(total_variance, variance_cut_threshold)
+
+    diagnostics: Dict[str, Array] = {
+        "log_evidence_per_event_sampled": log_I_s,
+        "ess_per_event_sampled": ess_s,
+        "rel_variance_per_event_sampled": rel_var_s,
+        "log_evidence_per_event_discrete": log_I_d,
         "expected_rate": expected_rate,
     }
     return log_likelihood, diagnostics

--- a/src/gwkokab/inference/poissonlikelihood_utils.py
+++ b/src/gwkokab/inference/poissonlikelihood_utils.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Any, Dict, Tuple
 
 import jax
@@ -14,6 +14,8 @@ from numpyro.distributions.distribution import Distribution
 __all__ = [
     "discrete_poisson_likelihood_fn",
     "analytical_poisson_likelihood_fn",
+    "sampled_poisson_likelihood_fn",
+    "low_ess_events",
 ]
 
 
@@ -159,3 +161,161 @@ def analytical_poisson_likelihood_fn(
         log_likelihood -= variance_tapering_factor
 
     return log_likelihood
+
+
+def sampled_poisson_likelihood_fn(
+    event_log_likelihood_fns: Sequence[Callable[[Array], Array]],
+    model_samples: Array,
+    model_log_weights: Array,
+    pdet_fn: Callable[[Array], Array] | None,
+    T_obs: Array,
+    variance_cut_threshold: float | None,
+) -> Tuple[Array, Dict[str, Array]]:
+    r"""Sample-mode (likelihood-mode) inhomogeneous-Poisson population likelihood.
+
+    This is the **dual** of :func:`analytical_poisson_likelihood_fn`.  Instead of
+    evaluating a pointwise model *density* ``p(x|θ)`` at samples drawn from each
+    event's posterior, it evaluates a per-event *likelihood* ``L_i(x)`` at samples
+    drawn from the **model itself** — exactly what a particle Monte-Carlo
+    population engine produces natively (draws + weights), with no grid and no
+    KDE.  It is the right path when the model is only available as weighted
+    samples (so no pointwise density exists) and a per-event likelihood evaluator
+    *is* available (e.g. a RIFT marginal-likelihood interpolant).
+
+    The per-event term of the inhomogeneous-Poisson likelihood is the importance
+    identity
+
+    .. math::
+
+        \mathcal{I}_i(\theta)=\int \mathcal{L}_i(x)\,n(x\mid\theta)\,dx
+        \;\approx\;\sum_j w_j\,\mathcal{L}_i(x_j),
+        \qquad x_j\sim n(\cdot\mid\theta),
+
+    where ``n(x|θ)`` is the merger **rate density (intensity)** and the weights
+    carry its normalisation, :math:`\sum_j w_j\approx\int n\,dx=` total rate.
+    The assembled log-likelihood mirrors the analytical form exactly
+
+    .. math::
+
+        \log\mathcal{L} = \sum_i \log\mathcal{I}_i
+        + n_\mathrm{events}\log T_\mathrm{obs} - \mu(\theta),
+        \qquad
+        \mu(\theta)=T_\mathrm{obs}\sum_j w_j\,p_\mathrm{det}(x_j),
+
+    so with one model sample, flat selection and ``T_obs = 1`` it reduces to the
+    same single-event Poisson term the analytical path produces — a faithful,
+    framework-standard generalisation, not a new estimator.
+
+    AD: the weights and samples flow from a reparameterised JAX sampler, so
+    ``jax.grad`` of this term w.r.t. the population parameters ``θ`` is well
+    defined.  Validate gradients against a many-key FD **mean**, never a
+    single-key FD (selection indices are held fixed under AD but move under a
+    single-key perturbation — see ``feedback_single_key_fd_not_ad_reference``).
+
+    Parameters
+    ----------
+    event_log_likelihood_fns : Sequence[Callable]
+        One duck-typed evaluator per event, ``L_i: (n_samples, n_dim) ->
+        (n_samples,)`` returning **log**-likelihood values at the model samples.
+    model_samples : Array
+        ``(n_samples, n_dim)`` draws from the model intensity ``n(·|θ)``.
+    model_log_weights : Array
+        ``(n_samples,)`` log-weights ``log w_j``; ``logsumexp`` of these is the
+        log total rate (per unit observing time).
+    pdet_fn : Callable or None
+        ``(n_samples, n_dim) -> (n_samples,)`` detection probability in ``(0, 1]``.
+        ``None`` ⇒ flat selection ``VT ≡ 1`` (``μ = T_obs · Σ w_j``), the
+        detected-rate convention with efficiency folded into the rate scale.
+    T_obs : Array
+        Observing time.
+    variance_cut_threshold : float or None
+        If set, penalise high total importance-sampling variance with
+        :func:`variance_tapering_fn` (same hygiene as the discrete mode).
+
+    Returns
+    -------
+    log_likelihood : Array
+        Scalar population log-likelihood.
+    diagnostics : Dict[str, Array]
+        Per-event arrays — ``log_evidence_per_event`` (``log I_i``),
+        ``ess_per_event`` (effective sample size of the IS estimate of
+        ``I_i``; collapses when the model puts few samples under an event),
+        ``rel_variance_per_event``, and the scalar ``expected_rate`` ``μ``.
+        Feed ``ess_per_event`` to :func:`low_ess_events` for a host-side
+        low-ESS warning (gate iii); the variance term is **not** optional when
+        events can sit in the tail of ``n(·|θ)``.
+    """
+    log_w = model_log_weights
+    n_samples = log_w.shape[0]
+    n_events = len(event_log_likelihood_fns)
+
+    # ---- per-event evidence  I_i = ∫ L_i n dx ≈ Σ_j w_j L_i(x_j) ----------
+    # Python loop over the (statically many) events, mirroring the discrete
+    # mode's loop over PE batches.  Each L_i may be a distinct callable, so we
+    # do not vmap across events.
+    log_I_list = []
+    log_sq_list = []
+    for L_i in event_log_likelihood_fns:
+        log_L = L_i(model_samples)  # (n_samples,)  log-likelihood values
+        a = log_w + log_L  # (n_samples,)  log(w_j · L_i(x_j))
+        log_I_list.append(jax.nn.logsumexp(a))  # log Σ_j w_j L_i(x_j)
+        log_sq_list.append(jax.nn.logsumexp(2.0 * a))  # log Σ_j (w_j L_i)^2
+
+    log_I = jnp.stack(log_I_list)  # (n_events,)
+    log_sq = jnp.stack(log_sq_list)  # (n_events,)
+
+    # Effective sample size of each importance estimate: (Σ a)^2 / Σ a^2.
+    log_ess = 2.0 * log_I - log_sq
+    ess = jnp.exp(log_ess)
+    # Relative variance of the (non-self-normalised) IS estimator of I_i, with
+    # the finite-sample correction, exactly as the discrete mode forms it.
+    rel_variance = jnp.exp(log_sq - 2.0 * log_I) - 1.0 / n_samples
+
+    total_ln_l = jnp.sum(log_I)
+
+    # ---- Poisson mean  μ = T_obs Σ_j w_j pdet(x_j)  (sample-based) ---------
+    if pdet_fn is None:
+        log_mu = jnp.log(T_obs) + jax.nn.logsumexp(log_w)
+    else:
+        log_pdet = jnp.log(pdet_fn(model_samples))  # (n_samples,)
+        log_mu = jnp.log(T_obs) + jax.nn.logsumexp(log_w + log_pdet)
+    expected_rate = jnp.exp(log_mu)
+
+    # log L = Σ_i log I_i + n_events·log T_obs − μ   (same shape as analytical)
+    log_likelihood = total_ln_l + n_events * jnp.log(T_obs) - expected_rate
+
+    if variance_cut_threshold is not None:
+        total_variance = jnp.nan_to_num(
+            jnp.sum(rel_variance),
+            nan=jnp.inf,
+            posinf=jnp.inf,
+            neginf=jnp.inf,
+        )
+        log_likelihood -= variance_tapering_fn(total_variance, variance_cut_threshold)
+
+    diagnostics: Dict[str, Array] = {
+        "log_evidence_per_event": log_I,
+        "ess_per_event": ess,
+        "rel_variance_per_event": rel_variance,
+        "expected_rate": expected_rate,
+    }
+    return log_likelihood, diagnostics
+
+
+def low_ess_events(
+    ess_per_event: Array,
+    n_samples: int,
+    frac: float = 0.1,
+) -> Array:
+    r"""Host-side helper: indices of events whose IS estimate is under-resolved.
+
+    An event whose true parameters sit in the tail of ``n(·|θ)`` receives very
+    few effective model samples, so its evidence estimate ``I_i`` is noisy.
+    Returns the integer indices where ``ess_per_event[i] < frac · n_samples``.
+    Intended for a non-jitted diagnostic pass (logging / warnings), not inside
+    the likelihood itself.
+    """
+    import numpy as _np
+
+    ess = _np.asarray(ess_per_event)
+    return _np.nonzero(ess < frac * n_samples)[0]

--- a/tests/test_mixed_poisson_likelihood.py
+++ b/tests/test_mixed_poisson_likelihood.py
@@ -1,0 +1,202 @@
+# Copyright 2023 The GWKokab Authors
+# SPDX-License-Identifier: Apache-2.0
+
+r"""Tests for the mixed-mode Poisson likelihood (sampled + discrete, one μ).
+
+Same closed-form problem as ``test_sampled_poisson_likelihood.py`` (1-D Gaussian
+population intensity × Gaussian event likelihoods), so every assertion is against
+an exact reference:
+
+* **MX0 — exact reduction.** With an empty discrete group, the mixed likelihood
+  is byte-for-byte the sampled likelihood.
+* **MX1 — discrete-only matches exact.** With an empty sampled group (model draws
+  kept only for the shared μ), the discrete per-event sum + sample-based μ
+  recovers the closed-form log L within MC error.
+* **MX2 — split equals whole.** Splitting ONE catalogue into a broad subset
+  (sampled term) and a narrow subset (discrete term, posterior samples vs the
+  model density) reproduces both the all-sampled log L and the exact log L within
+  MC error — the core equivalence justifying the mixed estimator.
+* **MX3 — diagnostics.** Per-event ESS arrays for both groups are exposed.
+"""
+
+import math
+
+import jax
+import jax.numpy as jnp
+import pytest
+
+from gwkokab.inference.poissonlikelihood_utils import (
+    mixed_poisson_likelihood_fn,
+    sampled_poisson_likelihood_fn,
+)
+from gwkokab.inference.event_likelihoods import gaussian_event_log_likelihoods
+
+jax.config.update("jax_enable_x64", True)
+
+_M, _S, _LOGR, _T = 1.0, 0.8, math.log(120.0), 2.0
+_D = jnp.asarray([-1.0, -0.3, 0.0, 0.5, 1.0, 1.4, 2.0, -0.8])[:, None]
+_SIGMA = jnp.asarray([0.3, 0.25, 0.4, 0.2, 0.35, 0.3, 0.45, 0.28])
+
+
+def _draw_model_samples(key, m, s, n, logr):
+    z = jax.random.normal(key, (n, 1))
+    return m + s * z, jnp.full((n,), logr - math.log(n))
+
+
+def _event_Ls(d=_D, sig=_SIGMA):
+    return gaussian_event_log_likelihoods(d, (sig**2)[:, None, None])
+
+
+def _exact_logL(d, sig, logr, m, s, T):
+    std = jnp.sqrt(sig**2 + s**2)
+    logI = logr + jax.scipy.stats.norm.logpdf(d, loc=m, scale=std)
+    return jnp.sum(logI) + d.shape[0] * jnp.log(T) - T * jnp.exp(logr)
+
+
+def _scaled_mvn(log_rate, m, s):
+    import numpyro.distributions as dist
+
+    class ScaledMVN(dist.MultivariateNormal):
+        def __init__(self, lr, loc, cov):
+            self._lr = lr
+            super().__init__(loc, covariance_matrix=cov)
+
+        def log_prob(self, v):
+            return self._lr + super().log_prob(v)
+
+    return ScaledMVN(log_rate, jnp.asarray([m]), jnp.asarray([[s**2]]))
+
+
+def _discrete_group(d, sig, key, M=20_000):
+    """Posterior samples y ~ N(d_i, sig_i) (=normalised event likelihood) with a
+    FLAT ref prior (log π = 0), so logsumexp(log ρ(y) − log π) − log M estimates
+    I_i = ∫ L_i n dx = E_{y~L_i}[n(y)] — the same I_i the sampled term forms."""
+    n = d.shape[0]
+    keys = jax.random.split(key, n)
+    pe = jnp.stack([d[i] + sig[i] * jax.random.normal(keys[i], (M, 1)) for i in range(n)])
+    data_group = (pe,)                                  # one batch (n, M, 1)
+    log_ref_priors_group = (jnp.zeros((n, M)),)         # flat π
+    masks_group = (jnp.ones((n, M), dtype=bool),)
+    N_pes = (jnp.full((n,), float(M)),)
+    return data_group, log_ref_priors_group, masks_group, N_pes
+
+
+# --------------------------------------------------------------------------- #
+def test_MX0_empty_discrete_reduces_to_sampled():
+    samples, log_w = _draw_model_samples(jax.random.PRNGKey(0), _M, _S, 200_000, _LOGR)
+    Ls = _event_Ls()
+    ll_s, _ = sampled_poisson_likelihood_fn(Ls, samples, log_w, None, _T, None)
+    ll_m, diag = mixed_poisson_likelihood_fn(
+        Ls, samples, log_w, None,
+        None, (), (), (), (),          # empty discrete group
+        _T, None,
+    )
+    assert jnp.abs(ll_s - ll_m) < 1e-9          # exact reduction
+    assert diag["ess_per_event_sampled"].shape == (len(Ls),)
+
+
+def test_MX1_discrete_only_matches_exact():
+    samples, log_w = _draw_model_samples(jax.random.PRNGKey(1), _M, _S, 200_000, _LOGR)
+    model = _scaled_mvn(_LOGR, _M, _S)
+    dg, lpg, mg, npes = _discrete_group(_D, _SIGMA, jax.random.PRNGKey(2))
+    ll_m, _ = mixed_poisson_likelihood_fn(
+        [], samples, log_w, None,           # empty sampled group (samples kept for μ)
+        model, dg, lpg, mg, npes,
+        _T, None,
+    )
+    ll_exact = _exact_logL(_D[:, 0], _SIGMA, _LOGR, _M, _S, _T)
+    assert jnp.isfinite(ll_m)
+    assert jnp.abs(ll_m - ll_exact) < 0.2
+
+
+def test_MX2_split_equals_whole_and_exact():
+    samples, log_w = _draw_model_samples(jax.random.PRNGKey(3), _M, _S, 300_000, _LOGR)
+    # all-sampled reference on the full catalogue
+    ll_all, _ = sampled_poisson_likelihood_fn(_event_Ls(), samples, log_w, None, _T, None)
+    ll_exact = _exact_logL(_D[:, 0], _SIGMA, _LOGR, _M, _S, _T)
+
+    # split: |d|>=0.5 -> broad/sampled ; |d|<0.5 -> narrow/discrete
+    broad = jnp.abs(_D[:, 0]) >= 0.5
+    import numpy as np
+    bi = np.where(np.asarray(broad))[0]
+    ni = np.where(~np.asarray(broad))[0]
+    Ls_broad = gaussian_event_log_likelihoods(_D[bi], (_SIGMA[bi] ** 2)[:, None, None])
+    model = _scaled_mvn(_LOGR, _M, _S)
+    dg, lpg, mg, npes = _discrete_group(_D[ni], _SIGMA[ni], jax.random.PRNGKey(4))
+
+    ll_mixed, diag = mixed_poisson_likelihood_fn(
+        Ls_broad, samples, log_w, None,
+        model, dg, lpg, mg, npes,
+        _T, None,
+    )
+    # same event count, same μ, same per-event evidences (different estimators)
+    assert jnp.abs(ll_mixed - ll_all) < 0.2
+    assert jnp.abs(ll_mixed - ll_exact) < 0.2
+    assert diag["ess_per_event_sampled"].shape == (len(bi),)
+    assert diag["log_evidence_per_event_discrete"].shape == (len(ni),)
+
+
+def test_MX4_numpyro_wrapper_finite_differentiable():
+    pytest.importorskip("gwkokab.models.utils")
+    from numpyro.infer.util import log_density
+    import numpyro.distributions as dist
+    from gwkokab.models.utils import JointDistribution
+    from gwkokab.inference.numpyro_mixed_poisson_likelihood import (
+        numpyro_mixed_poisson_likelihood,
+    )
+
+    n_samples = 40_000
+    z = jax.random.normal(jax.random.PRNGKey(8), (n_samples, 1))
+
+    def sampler_fn(loc_pop, log_rate, scale_pop):
+        samples = loc_pop + scale_pop * z
+        log_w = jnp.full((n_samples,), log_rate - math.log(n_samples))
+        return samples, log_w
+
+    def dist_fn(loc_pop, log_rate, scale_pop):
+        return _scaled_mvn(log_rate, loc_pop, scale_pop)
+
+    variables = {"loc_pop": dist.Normal(0.0, 3.0)}
+    variables_index = {"loc_pop": 0}
+    constant_params = {"log_rate": _LOGR, "scale_pop": _S}
+    priors = JointDistribution(dist.Normal(0.0, 3.0))
+
+    # split the fixed catalogue: broad -> sampled, narrow -> discrete
+    broad = jnp.abs(_D[:, 0]) >= 0.5
+    import numpy as np
+    bi = np.where(np.asarray(broad))[0]
+    ni = np.where(~np.asarray(broad))[0]
+    Ls_broad = gaussian_event_log_likelihoods(_D[bi], (_SIGMA[bi] ** 2)[:, None, None])
+    dg, lpg, mg, npes = _discrete_group(_D[ni], _SIGMA[ni], jax.random.PRNGKey(9))
+
+    model = numpyro_mixed_poisson_likelihood(
+        sampler_fn, dist_fn, priors, variables, constant_params, variables_index,
+        event_log_likelihood_fns=Ls_broad,
+        data_group=dg, log_ref_priors_group=lpg, masks_group=mg, N_pes=npes,
+        pdet_fn=None, variance_cut_threshold=None,
+    )
+
+    def potential(loc):
+        lp, _ = log_density(model, (_T,), {}, {"loc_pop": loc})
+        return lp
+
+    val = potential(jnp.asarray(_M))
+    grad = jax.grad(potential)(jnp.asarray(_M))
+    assert jnp.isfinite(val) and jnp.isfinite(grad)
+    # the likelihood peaks near the catalogue mean (~0.35 for the fixed _D);
+    # the gradient must bracket it: positive below, negative above.
+    g = jax.grad(potential)
+    assert g(jnp.asarray(-0.3)) > 0 and g(jnp.asarray(1.2)) < 0
+
+
+def test_MX3_diagnostics_present():
+    samples, log_w = _draw_model_samples(jax.random.PRNGKey(5), _M, _S, 50_000, _LOGR)
+    model = _scaled_mvn(_LOGR, _M, _S)
+    dg, lpg, mg, npes = _discrete_group(_D[:3], _SIGMA[:3], jax.random.PRNGKey(6), M=5_000)
+    _, diag = mixed_poisson_likelihood_fn(
+        _event_Ls(_D[3:], _SIGMA[3:]), samples, log_w, None,
+        model, dg, lpg, mg, npes, _T, None,
+    )
+    for k in ("ess_per_event_sampled", "log_evidence_per_event_sampled",
+              "log_evidence_per_event_discrete", "expected_rate"):
+        assert k in diag

--- a/tests/test_sampled_poisson_likelihood.py
+++ b/tests/test_sampled_poisson_likelihood.py
@@ -1,0 +1,331 @@
+# Copyright 2023 The GWKokab Authors
+# SPDX-License-Identifier: Apache-2.0
+
+r"""Test-problem sequence for the sample-mode (likelihood-mode) Poisson likelihood.
+
+The sampled path evaluates per-event *likelihoods* at samples drawn from the
+population *model*, the dual of the analytical path (model density at event
+samples).  This suite is a graded sequence on a problem where everything is
+available in closed form — a Gaussian population intensity with Gaussian event
+likelihoods — so each acceptance gate of
+``demo/PLAN_gwkokab_sampled_likelihood.md`` can be checked against an exact
+reference:
+
+* **TP0** — estimator identity: ``Σ_j w_j L_i(x_j)`` recovers the closed-form
+  evidence ``I_i = ∫ L_i n dx`` within MC error.
+* **TP1** — mode equivalence (**gate i**): on the same catalogue the sampled
+  log-likelihood matches both the exact log-likelihood and the existing
+  ``analytical_poisson_likelihood_fn`` within MC error, across a grid of θ.
+* **TP2** — AD through the sampler (**gate ii**): ``jax.grad`` of the sampled
+  log-likelihood w.r.t. a population parameter is finite and matches a
+  many-key finite-difference **mean** (not a single-key FD).
+* **TP3** — ESS diagnostic (**gate iii**): an event in the tail of ``n(·|θ)``
+  collapses its effective sample size and is flagged by ``low_ess_events``.
+* **TP4** — recovery: gradient ascent through the sampler recovers the true
+  population mean; and the numpyro wrapper assembles a finite, differentiable
+  log-density (full NUTS recovery lives in the demo for the workstation).
+
+The core function (TP0–TP3) needs only jax + numpyro.  TP1's density-mode
+cross-check and TP4's wrapper test import the real gwkokab inference layer and
+``importorskip`` when it (or its RIFT import) is unavailable — same pattern as
+the bridge's G6/G7 gates.
+"""
+
+import math
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from gwkokab.inference.poissonlikelihood_utils import (
+    low_ess_events,
+    sampled_poisson_likelihood_fn,
+)
+from gwkokab.inference.event_likelihoods import (
+    GaussianEventLikelihood,
+    gaussian_event_log_likelihoods,
+)
+
+
+jax.config.update("jax_enable_x64", True)
+
+
+# --------------------------------------------------------------------------- #
+# closed-form reference
+# --------------------------------------------------------------------------- #
+def _exact_log_evidence(d, sigma, log_rate, m, s):
+    r"""log I_i = log R + log N(d_i; m, sqrt(sigma_i^2 + s^2)) (1-D)."""
+    std = jnp.sqrt(sigma**2 + s**2)
+    return log_rate + jax.scipy.stats.norm.logpdf(d, loc=m, scale=std)
+
+
+def _exact_log_likelihood(d, sigma, log_rate, m, s, T_obs):
+    r"""Σ_i log I_i + n_events log T_obs − μ,   μ = T_obs · R (flat selection)."""
+    log_I = _exact_log_evidence(d, sigma, log_rate, m, s)
+    n_events = d.shape[0]
+    mu = T_obs * jnp.exp(log_rate)
+    return jnp.sum(log_I) + n_events * jnp.log(T_obs) - mu
+
+
+def _draw_model_samples(key, m, s, n_samples, log_rate):
+    """x_j ~ Normal(m, s), uniform log-weights summing (in exp) to the rate R."""
+    z = jax.random.normal(key, (n_samples, 1))
+    samples = m + s * z
+    log_w = jnp.full((n_samples,), log_rate - math.log(n_samples))
+    return samples, log_w
+
+
+# small fixed catalogue (1-D parameter x)
+_M_TRUE, _S_TRUE, _LOGR_TRUE, _T_OBS = 1.0, 0.8, math.log(120.0), 2.0
+_D = jnp.asarray([-1.0, -0.3, 0.0, 0.5, 1.0, 1.4, 2.0, -0.8])[:, None]  # (n_ev,1)
+_SIGMA = jnp.asarray([0.3, 0.25, 0.4, 0.2, 0.35, 0.3, 0.45, 0.28])
+
+
+def _event_likelihoods(d=_D, sigma=_SIGMA):
+    covs = (sigma**2)[:, None, None]  # (n_ev,1,1)
+    return gaussian_event_log_likelihoods(d, covs)
+
+
+def _draw_catalog(key, m_true, s, n_events, sigma_obs=0.3):
+    """Catalogue actually drawn from the population, so the MLE of the mean ~ m_true.
+
+    True source param x_i ~ Normal(m_true, s); observed event centre
+    d_i = x_i + sigma_obs · noise.  The marginal of d_i is Normal(m_true,
+    sqrt(s^2 + sigma_obs^2)), so the maximum-likelihood population mean tends to
+    m_true as n_events grows.
+    """
+    k1, k2 = jax.random.split(key)
+    x_true = m_true + s * jax.random.normal(k1, (n_events,))
+    d = (x_true + sigma_obs * jax.random.normal(k2, (n_events,)))[:, None]  # (n_ev,1)
+    sigma = jnp.full((n_events,), sigma_obs)
+    return d, sigma
+
+
+# --------------------------------------------------------------------------- #
+# TP0 — estimator identity
+# --------------------------------------------------------------------------- #
+def test_TP0_estimator_recovers_closed_form_evidence():
+    key = jax.random.PRNGKey(0)
+    n_samples = 200_000
+    samples, log_w = _draw_model_samples(key, _M_TRUE, _S_TRUE, n_samples, _LOGR_TRUE)
+
+    d, sigma = jnp.asarray([[0.5]]), jnp.asarray([0.3])
+    L = GaussianEventLikelihood(d[0], jnp.asarray([[sigma[0] ** 2]]))
+    log_I_hat = jax.nn.logsumexp(log_w + L(samples))
+    log_I_exact = _exact_log_evidence(d[0, 0], sigma[0], _LOGR_TRUE, _M_TRUE, _S_TRUE)
+
+    # MC relative error on I ~ 1/sqrt(ESS); 200k draws, central event -> tight.
+    assert jnp.abs(jnp.exp(log_I_hat - log_I_exact) - 1.0) < 5e-3
+
+
+# --------------------------------------------------------------------------- #
+# TP1 — mode equivalence (gate i)
+# --------------------------------------------------------------------------- #
+def test_TP1_sampled_matches_exact_loglikelihood():
+    key = jax.random.PRNGKey(1)
+    n_samples = 200_000
+    Ls = _event_likelihoods()
+
+    for offset in (-0.4, 0.0, 0.3):  # a small grid of population means θ=m
+        m = _M_TRUE + offset
+        samples, log_w = _draw_model_samples(key, m, _S_TRUE, n_samples, _LOGR_TRUE)
+        ll, diag = sampled_poisson_likelihood_fn(
+            Ls, samples, log_w, None, _T_OBS, None
+        )
+        ll_exact = _exact_log_likelihood(
+            _D[:, 0], _SIGMA, _LOGR_TRUE, m, _S_TRUE, _T_OBS
+        )
+        # Only Σ log I_i carries MC error (~O(0.05)); μ and the T_obs term are
+        # exact, so this absolute tolerance on the full log L is a sub-percent
+        # check on the per-event evidences.
+        assert jnp.isfinite(ll)
+        assert jnp.abs(ll - ll_exact) < 0.15
+        # μ is exact for flat selection (Σ w_j = R)
+        assert jnp.abs(diag["expected_rate"] - _T_OBS * math.exp(_LOGR_TRUE)) < 1e-6
+
+
+def test_TP1_sampled_matches_analytical_density_mode():
+    """Cross-check against gwkokab's own analytical (density-mode) estimator."""
+    pytest.importorskip("gwkokab.models.utils")
+    import numpyro.distributions as dist
+    from numpyro.distributions import constraints
+    from gwkokab.inference.poissonlikelihood_utils import (
+        analytical_poisson_likelihood_fn,
+    )
+
+    class ScaledMVN(dist.MultivariateNormal):
+        """log_prob = log R + log N(x; loc, cov) — a ScaledMixture-style intensity."""
+
+        def __init__(self, log_rate, loc, cov):
+            self._log_rate = log_rate
+            super().__init__(loc, covariance_matrix=cov)
+
+        def log_prob(self, value):
+            return self._log_rate + super().log_prob(value)
+
+    m, s = _M_TRUE - 0.2, _S_TRUE
+    model = ScaledMVN(_LOGR_TRUE, jnp.asarray([m]), jnp.asarray([[s**2]]))
+
+    def pmean(model_instance, T_obs):
+        return T_obs * jnp.exp(model_instance._log_rate), jnp.zeros(())
+
+    # density mode: event PE samples drawn FROM each event likelihood (proposal
+    # = the normalised event normal), ln_offset = -log M  ->  estimates the same
+    # I_i = ∫ L_i n dx as the sample mode.
+    key = jax.random.PRNGKey(2)
+    M = 20_000
+    n_ev = _D.shape[0]
+    keys = jax.random.split(key, n_ev)
+    pe = jnp.stack(
+        [_D[i] + _SIGMA[i] * jax.random.normal(keys[i], (M, 1)) for i in range(n_ev)]
+    )  # (n_ev, M, 1)
+    ln_offsets = jnp.full((n_ev, M), -math.log(M))
+    ll_density = analytical_poisson_likelihood_fn(
+        model, pmean, pe, ln_offsets, {"T_obs": _T_OBS}, None
+    )
+
+    # sample mode on the same population
+    samples, log_w = _draw_model_samples(
+        jax.random.PRNGKey(3), m, s, 400_000, _LOGR_TRUE
+    )
+    ll_sampled, _ = sampled_poisson_likelihood_fn(
+        _event_likelihoods(), samples, log_w, None, _T_OBS, None
+    )
+    # both are MC estimators of the same log L; agreement at the combined
+    # MC-error level confirms the two modes are the same identity.
+    assert jnp.abs(ll_sampled - ll_density) < 0.15
+
+
+# --------------------------------------------------------------------------- #
+# TP2 — AD through the sampler (gate ii)
+# --------------------------------------------------------------------------- #
+def _loglik_of_mean(m, z, log_w, Ls, T_obs):
+    """Reparameterised: samples = m + s*z, so grad flows through the draws."""
+    samples = m + _S_TRUE * z
+    ll, _ = sampled_poisson_likelihood_fn(Ls, samples, log_w, None, T_obs, None)
+    return ll
+
+
+def test_TP2_grad_through_sampler_matches_manykey_fd_mean():
+    Ls = _event_likelihoods()
+    n_samples = 30_000
+    log_w = jnp.full((n_samples,), _LOGR_TRUE - math.log(n_samples))
+    m0 = jnp.asarray(_M_TRUE)
+    h = 1e-3
+    n_keys = 12
+
+    grad_fn = jax.grad(lambda m, z: _loglik_of_mean(m, z, log_w, Ls, _T_OBS))
+
+    ad_grads, fd_grads = [], []
+    for k in range(n_keys):
+        z = jax.random.normal(jax.random.PRNGKey(100 + k), (n_samples, 1))
+        ad_grads.append(float(grad_fn(m0, z)))
+        # finite difference with the SAME draws (z fixed) — the reparameterised
+        # analogue of fixed-selection-replay FD; averaged over keys per gate (ii).
+        fp = _loglik_of_mean(m0 + h, z, log_w, Ls, _T_OBS)
+        fm = _loglik_of_mean(m0 - h, z, log_w, Ls, _T_OBS)
+        fd_grads.append(float((fp - fm) / (2 * h)))
+
+    ad_mean, fd_mean = np.mean(ad_grads), np.mean(fd_grads)
+    assert np.all(np.isfinite(ad_grads))
+    assert abs(ad_mean - fd_mean) < 1e-2 * (abs(fd_mean) + 1.0)
+
+
+# --------------------------------------------------------------------------- #
+# TP3 — ESS diagnostic (gate iii)
+# --------------------------------------------------------------------------- #
+def test_TP3_tail_event_collapses_ess():
+    key = jax.random.PRNGKey(4)
+    n_samples = 50_000
+    samples, log_w = _draw_model_samples(key, _M_TRUE, _S_TRUE, n_samples, _LOGR_TRUE)
+
+    d = jnp.asarray([[_M_TRUE], [_M_TRUE + 9.0 * _S_TRUE]])  # central, far-tail
+    sigma = jnp.asarray([0.3, 0.3])
+    Ls = gaussian_event_log_likelihoods(d, (sigma**2)[:, None, None])
+
+    _, diag = sampled_poisson_likelihood_fn(Ls, samples, log_w, None, _T_OBS, None)
+    ess = diag["ess_per_event"]
+
+    assert ess[0] > 0.05 * n_samples  # central event well resolved
+    assert ess[1] < 0.01 * n_samples  # tail event collapsed
+    flagged = low_ess_events(ess, n_samples, frac=0.05)
+    assert 1 in flagged and 0 not in flagged
+
+
+# --------------------------------------------------------------------------- #
+# TP4 — recovery
+# --------------------------------------------------------------------------- #
+def test_TP4a_gradient_ascent_recovers_population_mean():
+    """End-to-end: ascend log L(m) through the reparameterised sampler on a
+    catalogue actually drawn from the true population, recovering m_true."""
+    d, sigma = _draw_catalog(jax.random.PRNGKey(70), _M_TRUE, _S_TRUE, n_events=120)
+    Ls = gaussian_event_log_likelihoods(d, (sigma**2)[:, None, None])
+
+    n_samples = 40_000
+    z = jax.random.normal(jax.random.PRNGKey(7), (n_samples, 1))
+    log_w = jnp.full((n_samples,), _LOGR_TRUE - math.log(n_samples))
+
+    val_grad = jax.jit(
+        jax.value_and_grad(lambda m: _loglik_of_mean(m, z, log_w, Ls, _T_OBS))
+    )
+    m = jnp.asarray(_M_TRUE + 0.6)  # start displaced from truth
+    lr = 3e-3
+    for _ in range(300):
+        _, g = val_grad(m)
+        m = m + lr * g
+    # MLE of the mean ~ truth, up to O(std/sqrt(n_events)) sampling scatter.
+    assert jnp.abs(m - _M_TRUE) < 0.2
+
+
+def test_TP4b_numpyro_wrapper_assembles_finite_differentiable_density():
+    pytest.importorskip("gwkokab.models.utils")
+    numpyro = pytest.importorskip("numpyro")
+    from numpyro.infer.util import log_density
+    import numpyro.distributions as dist
+    from gwkokab.inference.numpyro_sampled_poisson_likelihood import (
+        numpyro_sampled_poisson_likelihood,
+    )
+
+    n_samples = 20_000
+    z = jax.random.normal(jax.random.PRNGKey(8), (n_samples, 1))
+
+    def sampler_fn(loc_pop, log_rate, scale_pop):
+        samples = loc_pop + scale_pop * z
+        log_w = jnp.full((n_samples,), log_rate - math.log(n_samples))
+        return samples, log_w
+
+    variables = {"loc_pop": dist.Normal(0.0, 3.0)}
+    variables_index = {"loc_pop": 0}
+    constant_params = {"log_rate": _LOGR_TRUE, "scale_pop": _S_TRUE}
+
+    # priors: a JointDistribution over sorted(variables) — single var here.
+    from gwkokab.models.utils import JointDistribution
+
+    priors = JointDistribution(dist.Normal(0.0, 3.0))
+
+    # catalogue drawn from the true population so the likelihood peaks at m_true
+    d, sigma = _draw_catalog(jax.random.PRNGKey(80), _M_TRUE, _S_TRUE, n_events=120)
+    event_Ls = gaussian_event_log_likelihoods(d, (sigma**2)[:, None, None])
+
+    model = numpyro_sampled_poisson_likelihood(
+        sampler_fn,
+        priors,
+        variables,
+        constant_params,
+        variables_index,
+        event_Ls,
+        None,
+        None,
+    )
+
+    def potential(loc):
+        lp, _ = log_density(model, (_T_OBS,), {}, {"loc_pop": loc})
+        return lp
+
+    val = potential(jnp.asarray(_M_TRUE))
+    grad = jax.grad(potential)(jnp.asarray(_M_TRUE))
+    assert jnp.isfinite(val) and jnp.isfinite(grad)
+    # from a start below the truth the posterior gradient points up toward it
+    g_lo = jax.grad(potential)(jnp.asarray(_M_TRUE - 0.5))
+    assert g_lo > 0


### PR DESCRIPTION
…elihood

Add the dual of the analytical/discrete density-mode likelihoods: evaluate per-event likelihoods L_i(x) at samples drawn from the population model, instead of the model density at samples drawn from each event. This unlocks population models available only as weighted Monte-Carlo draws (no pointwise density, no KDE) and makes the per-event draw probabilities continuous, differentiable parameters (AD + model selection).

  I_i(theta) = int L_i(x) n(x|theta) dx ~= sum_j w_j L_i(x_j),  x_j ~ n(.|theta)
  log L = sum_i log I_i + n_events*log T_obs - mu,  mu = T_obs sum_j w_j pdet(x_j)

With one sample, flat selection and T_obs=1 it reduces to the single-event Poisson term of the analytical path: a framework-standard generalisation, not a new estimator. Public API is additive; the two density modes are untouched (only dist_fn -> sampler_fn, model-density -> event-likelihood).

New:
* inference/poissonlikelihood_utils.py: sampled_poisson_likelihood_fn (per-event logsumexp over weighted model draws, sample-based mu via pdet_fn, per-event ESS/variance diagnostics) + low_ess_events host-side warning helper.
* inference/numpyro_sampled_poisson_likelihood.py, inference/flowMC_sampled_poisson_likelihood.py: wrappers mirroring the analytical ones, sampler_fn(**params)->(samples,log_w) replacing dist_fn.
* inference/event_likelihoods.py: GaussianEventLikelihood (closed-form CI reference) + RIFTMarginalLikelihood (production interpolant adapter interface).
* factory.get_likelihood_fn(..., "sampled") + inference/__init__ exports.
* tests/test_sampled_poisson_likelihood.py: graded test-problem sequence TP0 estimator identity, TP1 mode-equivalence (gate i, vs exact AND vs analytical_poisson_likelihood_fn), TP2 AD-through-sampler vs many-key FD-mean (gate ii), TP3 ESS collapse (gate iii), TP4 recovery (grad-ascent
  + numpyro wrapper log_density). 7/7 green.
* examples/sampled_likelihood_demo.py + sampled_likelihood_method.md: end-to-end NUTS recovery + method writeup.

Thread-back (engine side, later): expose particle_mc_jax draws+weights as sampler_fn and load per-event RIFT interpolants as L_i.

## Summary
<!--
Provide a clear, concise overview of:
- The purpose of this change
- Its business impact
- Expected outcomes
-->

Capability for using sample draws from a population (e.g., binary formation models) rather than continuous models; requires continuous likelihoods.

## Related To
<!--
Link associated items using GitHub keywords:
- "Closes #123"
- "Fixes #456"
- "Related to #789"
-->


## Description
<!--
Include comprehensive details about:
- Technical implementation approach
- Core components modified
- Key architectural decisions
- Dependencies affected
-->

## Additional Notes (Optional)
<!--
Include any supplementary information:
- Screenshots
- Performance metrics
- Technical considerations
- Future improvements
-->
